### PR TITLE
Add Block.epochNo for better perf

### DIFF
--- a/src/__test__/data_assertions/block_assertions.ts
+++ b/src/__test__/data_assertions/block_assertions.ts
@@ -5,6 +5,7 @@ export const block29021 = {
     epoch: {
       number: 1
     },
+    epochNo: 1,
     fees: '342316',
     id: '00aea2405f7cf4eb1d9e6694770ea25eeb113b857e377d22641aa1099742615d',
     merkelRootHash: '1acc618aebd703ab201ef790a379a0bd8748ac7a4ed4bf425e0b12f8b7afd812',
@@ -63,6 +64,7 @@ export const block29022 = {
     epoch: {
       number: 1
     },
+    epochNo: 1,
     fees: '0',
     id: 'bf13d9a80ad99a4f34edb8a3262dd8120e29bbe182732cd3b00bf3d1bb7c2380',
     merkelRootHash: '0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8',

--- a/src/__test__/tests/blocks.query.test.ts
+++ b/src/__test__/tests/blocks.query.test.ts
@@ -70,6 +70,7 @@ export function blocksTests (makeClient: () => Promise<TestClient>) {
                 epoch {
                     number
                 }
+                epochNo
                 fees
                 id
                 merkelRootHash

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -242,6 +242,7 @@ type Block {
   createdBy: String!
   # Genesis block does not belong to the 0th epoch, therefore it could be null
   epoch: Epoch
+  epochNo: Int!
   fees: String!
   id: Hash32HexString!
   # Ouroboros Classic Epoch Boundary blocks (EBB) do not have a merkel root


### PR DESCRIPTION
Fixes #91  This is a workaround due to the storage of epoch data not being optimised