### PR TITLE
Docker deployment upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,6 @@ pipeline {
     }
     stage('Test') {
       steps {
-        sh 'yarn start:test-stack --build -d'
         sh 'yarn test:e2e'
       }
       post {
@@ -39,13 +38,19 @@ pipeline {
        steps {
           sh 'yarn build'
           sh "docker build -t inputoutput/cardano-graphql:${env.GIT_COMMIT} ."
-          sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.GIT_BRANCH}"
        }
+    }
+    stage('Add extra Docker Tags') {
+      when {
+        branch '!*/*'
+      }
+      steps {
+        sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.GIT_BRANCH}"
+      }
     }
     stage('Publish') {
       steps {
-        sh "docker push inputoutput/cardano-graphql:${env.GIT_COMMIT}"
-        sh "docker push inputoutput/cardano-graphql:${env.GIT_BRANCH}"
+        sh "docker push inputoutput/cardano-graphql"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
     }
     stage('Tag and Push Release Docker Image') {
       when {
-        branch pattern: "release-\\d+", comparator: "REGEXP"}
+        branch pattern: "release-\\d+", comparator: "REGEXP"
       }
       steps {
         sh 'docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT_HASH} inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
     }
     stage('Test') {
       steps {
+        sh 'yarn start:test-stack --build -d'
         sh 'yarn test:e2e'
       }
       post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
     }
     stage('Tag and Push Release Docker Image') {
       when {
-        branch pattern: "release-\\d+", comparator: "REGEXP"
+        branch 'release/*'
       }
       steps {
         sh 'docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT_HASH} inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,17 +41,19 @@ pipeline {
           sh "docker build -t inputoutput/cardano-graphql:${env.GIT_COMMIT} ."
        }
     }
-    stage('Add extra Docker Tags') {
+    stage('Publish: git revision') {
+       steps {
+         sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.GIT_BRANCH}"
+         sh "docker push inputoutput/cardano-graphql:${env.GIT_COMMIT}"
+       }
+    }
+    stage('Publish: branch') {
       when {
         branch '!*/*'
       }
       steps {
         sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.GIT_BRANCH}"
-      }
-    }
-    stage('Publish') {
-      steps {
-        sh "docker push inputoutput/cardano-graphql"
+        sh "docker push inputoutput/cardano-graphql:${env.GIT_BRANCH}"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     stage('Install') {
       steps {
         sh 'yarn'
-        echo 'env.GIT_COMMIT_HASH'
+        echo "${env.GIT_COMMIT_HASH}"
       }
     }
     stage('Validate Code Style') {
@@ -44,12 +44,12 @@ pipeline {
     stage('Build') {
        steps {
           sh 'yarn build'
-          sh 'docker build -t inputoutput/cardano-graphql:${env.GIT_COMMIT} .'
+          sh "docker build -t inputoutput/cardano-graphql:${env.GIT_COMMIT} ."
        }
     }
     stage('Push Docker Commit Image') {
       steps {
-        sh 'docker push inputoutput/cardano-graphql:${env.GIT_COMMIT}'
+        sh "docker push inputoutput/cardano-graphql:${env.GIT_COMMIT}"
       }
     }
     stage('Tag and Push Develop Docker Image') {
@@ -57,8 +57,8 @@ pipeline {
         branch 'develop'
       }
       steps {
-        sh 'docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:develop'
-        sh 'docker push inputoutput/cardano-graphql:develop'
+        sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:develop"
+        sh "docker push inputoutput/cardano-graphql:develop"
       }
     }
     stage('Tag and Push Release Docker Image') {
@@ -66,8 +66,8 @@ pipeline {
         branch 'release/*'
       }
       steps {
-        sh 'docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}'
-        sh 'docker push inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}'
+        sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}"
+        sh "docker push inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,18 +41,27 @@ pipeline {
           sh "docker build -t inputoutput/cardano-graphql:${env.GIT_COMMIT} ."
        }
     }
-    stage('Publish: git revision') {
+    stage('Publish: Git Revision') {
        steps {
          sh "docker push inputoutput/cardano-graphql:${env.GIT_COMMIT}"
        }
     }
-    stage('Publish: branch') {
+    stage('Publish: Branch') {
       when {
         branch '!*/*'
       }
       steps {
         sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.GIT_BRANCH}"
         sh "docker push inputoutput/cardano-graphql:${env.GIT_BRANCH}"
+      }
+    }
+    stage('Publish: Release') {
+      when {
+        tag "v*"
+      }
+      steps {
+        sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.TAG_NAME}"
+        sh "docker push inputoutput/cardano-graphql:${env.TAG_NAME}"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,6 @@ pipeline {
     }
     stage('Publish: git revision') {
        steps {
-         sh "docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.GIT_BRANCH}"
          sh "docker push inputoutput/cardano-graphql:${env.GIT_COMMIT}"
        }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
     stage('Install') {
       steps {
         sh 'yarn'
+        echo 'env.GIT_COMMIT_HASH'
       }
     }
     stage('Validate Code Style') {
@@ -43,12 +44,12 @@ pipeline {
     stage('Build') {
        steps {
           sh 'yarn build'
-          sh 'docker build -t inputoutput/cardano-graphql:${env.GIT_COMMIT_HASH} .'
+          sh 'docker build -t inputoutput/cardano-graphql:${env.GIT_COMMIT} .'
        }
     }
-    stage('Push Docker Commit Hash Image') {
+    stage('Push Docker Commit Image') {
       steps {
-        sh 'docker push inputoutput/cardano-graphql:${env.GIT_COMMIT_HASH}'
+        sh 'docker push inputoutput/cardano-graphql:${env.GIT_COMMIT}'
       }
     }
     stage('Tag and Push Develop Docker Image') {
@@ -56,7 +57,7 @@ pipeline {
         branch 'develop'
       }
       steps {
-        sh 'docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT_HASH} inputoutput/cardano-graphql:develop'
+        sh 'docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:develop'
         sh 'docker push inputoutput/cardano-graphql:develop'
       }
     }
@@ -65,7 +66,7 @@ pipeline {
         branch 'release/*'
       }
       steps {
-        sh 'docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT_HASH} inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}'
+        sh 'docker tag inputoutput/cardano-graphql:${env.GIT_COMMIT} inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}'
         sh 'docker push inputoutput/cardano-graphql:${env.PACKAGE_JSON.version}'
       }
     }

--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,2 +1,0 @@
-FROM hasura/graphql-engine:v1.0.0-beta.10.cli-migrations
-COPY hasura/migrations /hasura-migrations

--- a/test/postgres/Dockerfile
+++ b/test/postgres/Dockerfile
@@ -1,4 +1,0 @@
-FROM postgres:11.5-alpine
-COPY test/postgres/init /docker-entrypoint-initdb.d
-ENV POSTGRES_USER postgres
-ENV POSTGRES_DB cexplorer


### PR DESCRIPTION
1. Removes the development Docker images for Hasura and PostgreSQL, that are currently being used as a convenience to provide a test stack for applications such as Cardano Explorer. The supported approach moving forward is to reference this git repo directly using git submodules for the test data, passing it into the official images [in the same way we do here internally](https://github.com/input-output-hk/cardano-graphql/blob/develop/docker/docker-compose.service-deps.yml). 
2. Docker images are now pushed to https://hub.docker.com/repository/docker/inputoutput/cardano-graphql, now including legally named branches such as `develop` or `master`, and new version tags matching `v*`