### PR TITLE
Change Transaction Fee from BigInt! -> String!

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -71,7 +71,7 @@ type Cardano {
 
 type Transaction {
   block: Block
-  fee: BigInt!
+  fee: String!
   id: Hash32HexString!
   inputs (
     limit: Int


### PR DESCRIPTION
This fixes a backwards compatibility issue where Transaction Fee used to be a string but in GraphQL was set to be a BigInt!. Changing this to String means it passes our data parity tests. 