### PR TITLE
fix metadata import url

### DIFF
--- a/nix/nixos/cardano-graphql-service.nix
+++ b/nix/nixos/cardano-graphql-service.nix
@@ -98,7 +98,7 @@ in {
           echo loop $x: waiting for graphql-engine 2 sec...
           sleep 2
         done
-        curl -d'{"type":"replace_metadata", "args":'$(jq -c < ${hasuraDbMetadata})'}' ${hasuraBaseUri}
+        curl -d'{"type":"replace_metadata", "args":'$(jq -c < ${hasuraDbMetadata})'}' ${hasuraBaseUri}/v1/query
       '';
       script = ''
         exec cardano-graphql


### PR DESCRIPTION
Wiped database and everything broke. In the process of renaming back the base Uri we lost the /v1/query on the metadata import. This adds it back.