### PR TITLE
Add data parity tests for epoch details

### DIFF
--- a/src/__test__/dataparitytests/blocks.parity.test.ts
+++ b/src/__test__/dataparitytests/blocks.parity.test.ts
@@ -3,14 +3,14 @@ import { TestClient } from '../TestClient'
 import { getDataFromAPI } from '../util'
 
 export function blocksTests (createClient: () => Promise<TestClient>) {
-  describe('blocks', () => {
+  describe('blocks ', () => {
     let client: TestClient
 
     beforeEach(async () => {
       client = await createClient()
     }, 60000)
 
-    it('returns the same height', async () => {
+    it('return the same height', async () => {
       const restResult = await getDataFromAPI('blocks/pages')
       const graphQLResult = await client.query({
         query: gql`query Blockheight {
@@ -20,8 +20,8 @@ export function blocksTests (createClient: () => Promise<TestClient>) {
                 }`
       })
 
-      const restResultBlockHeight = restResult['Right'][1][0]['cbeBlkHeight']
-      const graphQLBlockHeight = graphQLResult['data']['cardano']['blockHeight']
+      const restResultBlockHeight = restResult.Right[1][0].cbeBlkHeight
+      const graphQLBlockHeight = graphQLResult.data.cardano.blockHeight
 
       // As we're calling an external API to check equality on something that changes every 20 seconds
       // there is a small delta in the test condition to allow for this where the second API value can be

--- a/src/__test__/dataparitytests/blocks.parity.test.ts
+++ b/src/__test__/dataparitytests/blocks.parity.test.ts
@@ -1,11 +1,6 @@
 import gql from 'graphql-tag'
 import { TestClient } from '../TestClient'
-import fetch from 'node-fetch'
-
-async function getDataFromAPI (path: string) {
-  const response = await fetch(`https://explorer.cardano.org/api/${path}`)
-  return response.json()
-}
+import { getDataFromAPI } from '../util'
 
 export function blocksTests (createClient: () => Promise<TestClient>) {
   describe('blocks', () => {
@@ -21,7 +16,7 @@ export function blocksTests (createClient: () => Promise<TestClient>) {
         query: gql`query Blockheight {
                     cardano {
                         blockHeight
-                    }    
+                    }
                 }`
       })
 

--- a/src/__test__/dataparitytests/epochs.parity.test.ts
+++ b/src/__test__/dataparitytests/epochs.parity.test.ts
@@ -3,7 +3,7 @@ import { TestClient } from '../TestClient'
 import { getDataFromAPI, timestampToIsoStringWithoutTimezone } from '../util'
 
 export function epochsTests (createClient: () => Promise<TestClient>) {
-  describe('epochs', () => {
+  describe('epochs ', () => {
     let client: TestClient
     let restData: any
     let graphQLData: any
@@ -42,35 +42,35 @@ export function epochsTests (createClient: () => Promise<TestClient>) {
       graphQLData = graphQLResult.data.epochs[0].blocks[0]
     }, 30000)
 
-    it('Returns the same epoch number', async () => {
+    it('return the same epoch number', async () => {
       const restResultEpochNumber = restData.cbeEpoch
       const graphQLEpochNumber = graphQLData.epochNo
 
       expect(restResultEpochNumber).toEqual(graphQLEpochNumber)
     })
 
-    it('Returns the same slot number', async () => {
+    it('return the same slot number', async () => {
       const restResultSlotNumber = restData.cbeSlot
       const graphQLSlotNumber = graphQLData.slotWithinEpoch
 
       expect(restResultSlotNumber).toEqual(graphQLSlotNumber)
     })
 
-    it('Returns the same block height', async () => {
+    it('return the same block height', async () => {
       const restResultBlockHeight = restData.cbeBlkHeight
       const graphQLBlockHeight = graphQLData.number
 
       expect(restResultBlockHeight).toEqual(graphQLBlockHeight)
     })
 
-    it('Returns the same block hash', async () => {
+    it('return the same block hash', async () => {
       const restResultBlockHash = restData.cbeBlkHash
       const graphQLBlockHash = graphQLData.id
 
       expect(restResultBlockHash).toEqual(graphQLBlockHash)
     })
 
-    it('Returns the same block creation time', async () => {
+    it('return the same block creation time', async () => {
       const restResultBlockCreationUnixEpochTime = restData.cbeTimeIssued
       const graphQLBlockCreationDateTime = graphQLData.createdAt
       const restResultBlockCreationDateTime = timestampToIsoStringWithoutTimezone(restResultBlockCreationUnixEpochTime);
@@ -78,14 +78,14 @@ export function epochsTests (createClient: () => Promise<TestClient>) {
       expect(restResultBlockCreationDateTime).toEqual(graphQLBlockCreationDateTime)
     })
 
-    it('Returns the same transactions count', async () => {
+    it('return the same transactions count', async () => {
       const restResultTxCount = restData.cbeTxNum
       const graphQLTxCount = parseInt(graphQLData.transactionsCount)
 
       expect(restResultTxCount).toEqual(graphQLTxCount)
     })
 
-    it('Returns the same total output', async () => {
+    it('return the same total output', async () => {
       const restResultTotalSent = parseInt(restData.cbeTotalSent.getCoin)
       let graphQLTotalSent = 0;
 
@@ -98,21 +98,21 @@ export function epochsTests (createClient: () => Promise<TestClient>) {
       expect(restResultTotalSent).toEqual(graphQLTotalSent)
     })
 
-    it('Returns the same block size', async () => {
+    it('return the same block size', async () => {
       const restResultBlockSize = restData.cbeSize
       const graphQLBlockSize = graphQLData.size
 
       expect(restResultBlockSize).toEqual(graphQLBlockSize)
     })
 
-    it('Returns the same block leader', async () => {
+    it('return the same block leader', async () => {
       const restResultBlockLeader = restData.cbeBlockLead
       const graphQLBlockLeader = graphQLData.createdBy.split("-")[1]
 
       expect(restResultBlockLeader).toMatch(graphQLBlockLeader)
     })
 
-    it('Returns the same fee', async () => {
+    it('return the same fee', async () => {
       const restResultFee = parseInt(restData.cbeFees.getCoin)
       const graphQLFee = graphQLData.fees
 

--- a/src/__test__/dataparitytests/epochs.parity.test.ts
+++ b/src/__test__/dataparitytests/epochs.parity.test.ts
@@ -16,16 +16,16 @@ export function epochsTests (createClient: () => Promise<TestClient>) {
       restData = restResult.Right[0]
       const graphQLResult = await client.query({
         query: gql`query EpochDetails{
-			epochs(where: {number:{_eq:${epoch}}}){
+            epochs(where: {number:{_eq:${epoch}}}){
                             number
                             startedAt
                             lastBlockTime
-			    blocks (where: {slotWithinEpoch:{_eq:${slot}}}){
+                blocks (where: {slotWithinEpoch:{_eq:${slot}}}){
                               slotNo
                               epochNo
                               slotWithinEpoch
                               number
-                              id
+                              hash
                               createdAt
                               transactionsCount
                               transactions{
@@ -73,7 +73,7 @@ export function epochsTests (createClient: () => Promise<TestClient>) {
     it('return the same block creation time', async () => {
       const restResultBlockCreationUnixEpochTime = restData.cbeTimeIssued
       const graphQLBlockCreationDateTime = graphQLData.createdAt
-      const restResultBlockCreationDateTime = timestampToIsoStringWithoutTimezone(restResultBlockCreationUnixEpochTime);
+      const restResultBlockCreationDateTime = timestampToIsoStringWithoutTimezone(restResultBlockCreationUnixEpochTime)
 
       expect(restResultBlockCreationDateTime).toEqual(graphQLBlockCreationDateTime)
     })
@@ -87,13 +87,13 @@ export function epochsTests (createClient: () => Promise<TestClient>) {
 
     it('return the same total output', async () => {
       const restResultTotalSent = parseInt(restData.cbeTotalSent.getCoin)
-      let graphQLTotalSent = 0;
+      let graphQLTotalSent = 0
 
       graphQLData.transactions.forEach(
         (tx: any) => {
-            graphQLTotalSent += parseInt(tx.totalOutput)
+          graphQLTotalSent += parseInt(tx.totalOutput)
         }
-      );
+      )
 
       expect(restResultTotalSent).toEqual(graphQLTotalSent)
     })
@@ -107,7 +107,7 @@ export function epochsTests (createClient: () => Promise<TestClient>) {
 
     it('return the same block leader', async () => {
       const restResultBlockLeader = restData.cbeBlockLead
-      const graphQLBlockLeader = graphQLData.createdBy.split("-")[1]
+      const graphQLBlockLeader = graphQLData.createdBy.split('-')[1]
 
       expect(restResultBlockLeader).toMatch(graphQLBlockLeader)
     })

--- a/src/__test__/dataparitytests/epochs.parity.test.ts
+++ b/src/__test__/dataparitytests/epochs.parity.test.ts
@@ -1,0 +1,122 @@
+import gql from 'graphql-tag'
+import { TestClient } from '../TestClient'
+import { getDataFromAPI, timestampToIsoStringWithoutTimezone } from '../util'
+
+export function epochsTests (createClient: () => Promise<TestClient>) {
+  describe('epochs', () => {
+    let client: TestClient
+    let restData: any
+    let graphQLData: any
+    const epoch = 111
+    const slot = 3313
+
+    beforeAll(async () => {
+      client = await createClient()
+      const restResult = await getDataFromAPI(`epochs/${epoch}/${slot}`)
+      restData = restResult.Right[0]
+      const graphQLResult = await client.query({
+        query: gql`query EpochDetails{
+			epochs(where: {number:{_eq:${epoch}}}){
+                            number
+                            startedAt
+                            lastBlockTime
+			    blocks (where: {slotWithinEpoch:{_eq:${slot}}}){
+                              slotNo
+                              epochNo
+                              slotWithinEpoch
+                              number
+                              id
+                              createdAt
+                              transactionsCount
+                              transactions{
+                                totalOutput
+                              }
+                              size
+                              createdBy
+                              fees
+                            }
+                            output
+                          }
+                        }`
+      })
+      graphQLData = graphQLResult.data.epochs[0].blocks[0]
+    }, 30000)
+
+    it('Returns the same epoch number', async () => {
+      const restResultEpochNumber = restData.cbeEpoch
+      const graphQLEpochNumber = graphQLData.epochNo
+
+      expect(restResultEpochNumber).toEqual(graphQLEpochNumber)
+    })
+
+    it('Returns the same slot number', async () => {
+      const restResultSlotNumber = restData.cbeSlot
+      const graphQLSlotNumber = graphQLData.slotWithinEpoch
+
+      expect(restResultSlotNumber).toEqual(graphQLSlotNumber)
+    })
+
+    it('Returns the same block height', async () => {
+      const restResultBlockHeight = restData.cbeBlkHeight
+      const graphQLBlockHeight = graphQLData.number
+
+      expect(restResultBlockHeight).toEqual(graphQLBlockHeight)
+    })
+
+    it('Returns the same block hash', async () => {
+      const restResultBlockHash = restData.cbeBlkHash
+      const graphQLBlockHash = graphQLData.id
+
+      expect(restResultBlockHash).toEqual(graphQLBlockHash)
+    })
+
+    it('Returns the same block creation time', async () => {
+      const restResultBlockCreationUnixEpochTime = restData.cbeTimeIssued
+      const graphQLBlockCreationDateTime = graphQLData.createdAt
+      const restResultBlockCreationDateTime = timestampToIsoStringWithoutTimezone(restResultBlockCreationUnixEpochTime);
+
+      expect(restResultBlockCreationDateTime).toEqual(graphQLBlockCreationDateTime)
+    })
+
+    it('Returns the same transactions count', async () => {
+      const restResultTxCount = restData.cbeTxNum
+      const graphQLTxCount = parseInt(graphQLData.transactionsCount)
+
+      expect(restResultTxCount).toEqual(graphQLTxCount)
+    })
+
+    it('Returns the same total output', async () => {
+      const restResultTotalSent = parseInt(restData.cbeTotalSent.getCoin)
+      let graphQLTotalSent = 0;
+
+      graphQLData.transactions.forEach(
+        (tx: any) => {
+            graphQLTotalSent += parseInt(tx.totalOutput)
+        }
+      );
+
+      expect(restResultTotalSent).toEqual(graphQLTotalSent)
+    })
+
+    it('Returns the same block size', async () => {
+      const restResultBlockSize = restData.cbeSize
+      const graphQLBlockSize = graphQLData.size
+
+      expect(restResultBlockSize).toEqual(graphQLBlockSize)
+    })
+
+    it('Returns the same block leader', async () => {
+      const restResultBlockLeader = restData.cbeBlockLead
+      const graphQLBlockLeader = graphQLData.createdBy.split("-")[1]
+
+      expect(restResultBlockLeader).toMatch(graphQLBlockLeader)
+    })
+
+    it('Returns the same fee', async () => {
+      const restResultFee = parseInt(restData.cbeFees.getCoin)
+      const graphQLFee = graphQLData.fees
+
+      expect(restResultFee).toEqual(graphQLFee)
+    })
+  })
+}

--- a/src/__test__/dataparitytests/index.ts
+++ b/src/__test__/dataparitytests/index.ts
@@ -1,2 +1,3 @@
 export * from './blocks.parity.test'
 export * from './transactions.parity.test'
+export * from './epochs.parity.test'

--- a/src/__test__/dataparitytests/transactions.parity.test.ts
+++ b/src/__test__/dataparitytests/transactions.parity.test.ts
@@ -38,9 +38,9 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                 includedAt
                               }
                             }`
-        })
-        graphQLData = graphQLResult.data.transactions[0]
-      }, 30000)
+      })
+      graphQLData = graphQLResult.data.transactions[0]
+    }, 30000)
 
     it('return the correct hash', async () => {
       const restResultId = restData.ctsId

--- a/src/__test__/dataparitytests/transactions.parity.test.ts
+++ b/src/__test__/dataparitytests/transactions.parity.test.ts
@@ -5,104 +5,17 @@ import { getDataFromAPI, timestampToIsoStringWithoutTimezone } from '../util'
 export function transactionTests (createClient: () => Promise<TestClient>) {
   describe('transactions', () => {
     let client: TestClient
+    let restData: any
+    let graphQLData: any
 
-    beforeEach(async () => {
+    beforeAll(async () => {
       client = await createClient()
-    }, 60000)
-
-    it('return the correct hash', async () => {
       const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
+      restData = restResult.Right
       const graphQLResult = await client.query({
         query: gql`query TxByHash{
                           transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                          {
-                            hash
-                          }
-                        }`
-      })
-
-      const restResultHash = restResult['Right']['ctsId']
-      const graphQLHash = graphQLResult['data']['transactions'][0]['hash']
-
-      expect(graphQLHash).toEqual(restResultHash)
-    })
-
-    it('return the correct Result Fee', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                          transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                          {
-                            fee
-                          }
-                        }`
-      })
-
-      const restResultFee = restResult['Right']['ctsFees']['getCoin']
-      const graphQLFee = graphQLResult['data']['transactions'][0]['fee']
-
-      expect(graphQLFee).toEqual(parseInt(restResultFee))
-    })
-
-    it('return the correct Total Output', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                          transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                          {
-                            totalOutput
-                          }
-                        }`
-      })
-
-      const restResultTotalOutput = restResult['Right']['ctsTotalOutput']['getCoin']
-      const graphQLTotalOutput = graphQLResult['data']['transactions'][0]['totalOutput']
-
-      expect(graphQLTotalOutput).toEqual(restResultTotalOutput)
-    })
-
-    it('return the correct Block Height', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                              transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                              {
-                                hash
-                                fee
-                                block{
-                                  number
-                                  createdAt
-                                }
-                                inputs {
-                                  address
-                                  value
-                                  sourceTxHash
-                                  sourceTxIndex
-                                }
-                                outputs{
-                                  address
-                                  index
-                                  value
-                                }
-
-                                totalOutput
-                                includedAt
-                              }
-                            }`
-      })
-
-      const restResultTotalOutput = restResult['Right']['ctsBlockHeight']
-      const graphQLTotalOutput = graphQLResult['data']['transactions'][0]['block']['number']
-
-      expect(graphQLTotalOutput).toEqual(restResultTotalOutput)
-    })
-
-    it('return the correct Input Addresses', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                              transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                              {
+                                                       {
                                 hash
                                 fee
                                 block{
@@ -115,7 +28,7 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                   sourceTxHash
                                   sourceTxIndex
                                 }
-                                outputs(order_by: { index: asc }){
+                                outputs(order_by: { index: asc }) {
                                   address
                                   index
                                   value
@@ -125,234 +38,120 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                 includedAt
                               }
                             }`
-      })
+        })
+        graphQLData = graphQLResult.data.transactions[0]
+      }, 30000)
 
-      const restResultInputs = restResult['Right']['ctsInputs']
+    it('return the correct hash', async () => {
+      const restResultId = restData.ctsId
+      const graphQLHash = graphQLData.hash
+
+      expect(graphQLHash).toEqual(restResultId)
+    })
+
+    it('return the correct Result Fee', async () => {
+      const restResultFee = restData.ctsFees.getCoin
+      const graphQLFee = graphQLData.fee
+
+      expect(graphQLFee).toEqual(parseInt(restResultFee))
+    })
+
+    it('return the correct Total Output', async () => {
+      const restResultTotalOutput = restData.ctsTotalOutput.getCoin
+      const graphQLTotalOutput = graphQLData.totalOutput
+
+      expect(graphQLTotalOutput).toEqual(restResultTotalOutput)
+    })
+
+    it('return the correct Block Height', async () => {
+      const restResultTotalOutput = restData.ctsBlockHeight
+      const graphQLTotalOutput = graphQLData.block.number
+
+      expect(graphQLTotalOutput).toEqual(restResultTotalOutput)
+    })
+
+    it('return the correct Input Addresses', async () => {
+      const restResultInputs = restData.ctsInputs
       const restResultAddresses = []
 
       for (const input of restResultInputs) {
         restResultAddresses.push(input[0])
       }
 
-      const graphQLInputs = graphQLResult['data']['transactions'][0]['inputs']
+      const graphQLInputs = graphQLData.inputs
       const graphQLAddresses = []
 
       for (const input of graphQLInputs) {
-        graphQLAddresses.push(input['address'])
+        graphQLAddresses.push(input.address)
       }
 
       expect(graphQLAddresses).toEqual(restResultAddresses)
     })
 
     it('return the correct Input Values', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                              transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                              {
-                                hash
-                                fee
-                                block{
-                                  number
-                                  createdAt
-                                }
-                                inputs {
-                                  address
-                                  value
-                                  sourceTxHash
-                                  sourceTxIndex
-                                }
-                                outputs{
-                                  address
-                                  index
-                                  value
-                                }
-
-                                totalOutput
-                                includedAt
-                              }
-                            }`
-      })
-
-      const restResultInputs = restResult['Right']['ctsInputs']
+      const restResultInputs = restData.ctsInputs
       let restResultValues = 0
 
       for (const input of restResultInputs) {
-        restResultValues += Number(input[1]['getCoin'])
+        restResultValues += Number(input[1].getCoin)
       }
 
-      const graphQLInputs = graphQLResult['data']['transactions'][0]['inputs']
+      const graphQLInputs = graphQLData.inputs
       let graphQLValues = 0
 
       for (const input of graphQLInputs) {
-        graphQLValues += Number(input['value'])
+        graphQLValues += Number(input.value)
       }
 
       expect(graphQLValues).toEqual(restResultValues)
     })
 
     it('return the correct Output Addresses', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                              transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                              {
-                                hash
-                                fee
-                                block{
-                                  number
-                                  createdAt
-                                }
-                                inputs(order_by: { index: asc }) {
-                                  address
-                                  value
-                                  sourceTxHash
-                                  sourceTxIndex
-                                }
-                                outputs(order_by: { index: asc }){
-                                  address
-                                  index
-                                  value
-                                }
-
-                                totalOutput
-                                includedAt
-                              }
-                            }`
-      })
-
-      const restResultOutputs = restResult['Right']['ctsOutputs']
+      const restResultOutputs = restData.ctsOutputs
       const restResultAddresses = []
 
       for (const output of restResultOutputs) {
         restResultAddresses.push(output[0])
       }
 
-      const graphQLOutputs = graphQLResult['data']['transactions'][0]['outputs']
+      const graphQLOutputs = graphQLData.outputs
       const graphQLAddresses = []
 
       for (const output of graphQLOutputs) {
-        graphQLAddresses.push(output['address'])
+        graphQLAddresses.push(output.address)
       }
 
       expect(graphQLAddresses).toEqual(restResultAddresses)
     })
 
     it('return the correct Output Values', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                              transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                              {
-                                hash
-                                fee
-                                block{
-                                  number
-                                  createdAt
-                                }
-                                inputs {
-                                  address
-                                  value
-                                  sourceTxHash
-                                  sourceTxIndex
-                                }
-                                outputs{
-                                  address
-                                  index
-                                  value
-                                }
-
-                                totalOutput
-                                includedAt
-                              }
-                            }`
-      })
-
-      const restResultOutputs = restResult['Right']['ctsOutputs']
+      const restResultOutputs = restData.ctsOutputs
       let restResultValues = 0
 
       for (const output of restResultOutputs) {
-        restResultValues += Number(output[1]['getCoin'])
+        restResultValues += Number(output[1].getCoin)
       }
 
-      const graphQLOutputs = graphQLResult['data']['transactions'][0]['outputs']
+      const graphQLOutputs = graphQLData.outputs
       let graphQLValues = 0
 
       for (const output of graphQLOutputs) {
-        graphQLValues += Number(output['value'])
+        graphQLValues += Number(output.value)
       }
 
       expect(graphQLValues).toEqual(restResultValues)
     })
 
     it('have the same block creation time', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                              transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                              {
-                                hash
-                                fee
-                                block{
-                                  number
-                                  createdAt
-                                }
-                                inputs {
-                                  address
-                                  value
-                                  sourceTxHash
-                                  sourceTxIndex
-                                }
-                                outputs{
-                                  address
-                                  index
-                                  value
-                                }
-
-                                totalOutput
-                                includedAt
-                              }
-                            }`
-      })
-
-      const restResultBlockTime = restResult['Right']['ctsBlockTimeIssued']
-      const graphQLBlockTime = graphQLResult['data']['transactions'][0]['block']['createdAt']
+      const restResultBlockTime = restData.ctsBlockTimeIssued
+      const graphQLBlockTime = graphQLData.block.createdAt
 
       expect(graphQLBlockTime).toEqual(timestampToIsoStringWithoutTimezone(restResultBlockTime))
     })
 
     it('have the same transaction inclusion time', async () => {
-      const restResult = await getDataFromAPI('txs/summary/1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762')
-      const graphQLResult = await client.query({
-        query: gql`query TxByHash{
-                              transactions (where: {hash: {_eq:"1ac36644733c367ee4c551413d799d2e395d6ddfe14bebf1c281e6e826901762"}})
-                              {
-                                hash
-                                fee
-                                block{
-                                  number
-                                  createdAt
-                                }
-                                inputs {
-                                  address
-                                  value
-                                  sourceTxHash
-                                  sourceTxIndex
-                                }
-                                outputs{
-                                  address
-                                  index
-                                  value
-                                }
-
-                                totalOutput
-                                includedAt
-                              }
-                            }`
-      })
-
-      const restResultTransactionTime = restResult['Right']['ctsTxTimeIssued']
-      const graphQLTransactionTime = graphQLResult['data']['transactions'][0]['includedAt']
+      const restResultTransactionTime = restData.ctsTxTimeIssued
+      const graphQLTransactionTime = graphQLData.includedAt
 
       expect(graphQLTransactionTime).toEqual(timestampToIsoStringWithoutTimezone(restResultTransactionTime))
     })

--- a/src/__test__/dataparitytests/transactions.parity.test.ts
+++ b/src/__test__/dataparitytests/transactions.parity.test.ts
@@ -1,15 +1,6 @@
 import gql from 'graphql-tag'
 import { TestClient } from '../TestClient'
-import fetch from 'node-fetch'
-
-async function getDataFromAPI (path: string) {
-  const response = await fetch(`https://explorer.cardano.org/api/${path}`)
-  return response.json()
-}
-
-function timestampToIsoStringWithoutTimezone (timestamp: number): string {
-  return new Date(timestamp * 1000).toISOString().substr(0, 19)
-}
+import { getDataFromAPI, timestampToIsoStringWithoutTimezone } from '../util'
 
 export function transactionTests (createClient: () => Promise<TestClient>) {
   describe('transactions', () => {
@@ -93,7 +84,7 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                   index
                                   value
                                 }
-    
+
                                 totalOutput
                                 includedAt
                               }
@@ -129,7 +120,7 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                   index
                                   value
                                 }
-    
+
                                 totalOutput
                                 includedAt
                               }
@@ -176,7 +167,7 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                   index
                                   value
                                 }
-    
+
                                 totalOutput
                                 includedAt
                               }
@@ -270,7 +261,7 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                   index
                                   value
                                 }
-    
+
                                 totalOutput
                                 includedAt
                               }
@@ -317,7 +308,7 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                   index
                                   value
                                 }
-    
+
                                 totalOutput
                                 includedAt
                               }
@@ -353,7 +344,7 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
                                   index
                                   value
                                 }
-    
+
                                 totalOutput
                                 includedAt
                               }

--- a/src/__test__/util.ts
+++ b/src/__test__/util.ts
@@ -1,0 +1,10 @@
+import fetch from 'node-fetch'
+
+export async function getDataFromAPI (path: string) {
+  const response = await fetch(`https://explorer.cardano.org/api/${path}`)
+  return response.json()
+}
+
+export function timestampToIsoStringWithoutTimezone (timestamp: number): string {
+  return new Date(timestamp * 1000).toISOString().substr(0, 19)
+}


### PR DESCRIPTION
Add data parity tests for epochs. 
Refactored transaction tests to reduce amount of API calls.