### PR TITLE
Fix/add transaction block index

### DIFF
--- a/hasura/config.yaml
+++ b/hasura/config.yaml
@@ -1,0 +1,6 @@
+version: 2
+endpoint: http://localhost:8090
+metadata_directory: metadata
+actions:
+  kind: synchronous
+  handler_webhook_baseurl: http://localhost:3000

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -157,11 +157,12 @@
     permission:
       columns:
       - blockHash
+      - blockIndex
       - fee
       - hash
-      - totalOutput
-      - size
       - includedAt
+      - size
+      - totalOutput
       filter: {}
       limit: 100
       allow_aggregations: true

--- a/hasura/migrations/1589369664961_init/up.sql
+++ b/hasura/migrations/1589369664961_init/up.sql
@@ -51,7 +51,6 @@ select
   tx.hash as hash,
   cast((select sum("value") from tx_out where tx_id = tx.id) as bigint) as "totalOutput",
   tx.size,
-  tx.block_index AS "blockIndex",
   block.time as "includedAt"
 from
   tx

--- a/hasura/migrations/1589369664961_init/up.sql
+++ b/hasura/migrations/1589369664961_init/up.sql
@@ -28,7 +28,7 @@ select
   (select slot_duration from meta) as "slotDuration",
   (select start_time from meta) as "startTime",
   (select protocol_const from meta) as "protocolConst",
-	(select network_name from meta) as "networkName"
+  (select network_name from meta) as "networkName"
 from "Block"
 where number is not null
 order by number desc
@@ -50,7 +50,8 @@ select
   COALESCE(tx.fee, 0) as fee,
   tx.hash as hash,
   cast((select sum("value") from tx_out where tx_id = tx.id) as bigint) as "totalOutput",
-	tx.size,
+  tx.size,
+  tx.block_index AS "blockIndex",
   block.time as "includedAt"
 from
   tx

--- a/hasura/migrations/1590383124093_add_transaction_block_index/down.sql
+++ b/hasura/migrations/1590383124093_add_transaction_block_index/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "Transaction" CASCADE;

--- a/hasura/migrations/1590383124093_add_transaction_block_index/up.sql
+++ b/hasura/migrations/1590383124093_add_transaction_block_index/up.sql
@@ -1,0 +1,13 @@
+create or replace view "Transaction" as
+select
+  block.hash as "blockHash",
+  COALESCE(tx.fee, 0) as fee,
+  tx.hash as hash,
+  cast((select sum("value") from tx_out where tx_id = tx.id) as bigint) as "totalOutput",
+  tx.size,
+  block.time as "includedAt",
+  tx.block_index AS "blockIndex"
+from
+  tx
+inner join block
+  on block.id = tx.block;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "yarn codegen:internal && yarn codegen:external && tsc -p . && shx cp src/schema.graphql dist/ && shx cp -R src/graphql_operations dist/graphql_operations",
     "prestart": "yarn build",
     "start": "HASURA_URI=http://localhost:8090 node dist/index.js",
-    "test:tdd": "yarn service-dependencies up -d && NODE_ENV=test TEST_MODE=integration jest suite",
+    "test:tdd": "NODE_ENV=test TEST_MODE=integration jest suite",
     "test:e2e": "docker-compose up -d && NODE_ENV=test TEST_MODE=e2e jest suite",
     "test:dataparity": "docker-compose up -d && NODE_ENV=test TEST_MODE=e2e jest dataparity.test",
     "loadtest:byron-staging": "artillery run test/loadtest/byron-staging-config.yml"

--- a/src/__test__/__snapshots__/suite.test.ts.snap
+++ b/src/__test__/__snapshots__/suite.test.ts.snap
@@ -319,6 +319,7 @@ Object {
       "block": Object {
         "number": 29021,
       },
+      "blockIndex": 0,
       "fee": 171246,
       "hash": "05ad8b467095e0886713a38231ab9fe84e4031a433a9400ebf70ec9415e20102",
       "inputs": Array [
@@ -347,6 +348,7 @@ Object {
       "block": Object {
         "number": 29021,
       },
+      "blockIndex": 1,
       "fee": 171070,
       "hash": "e680432562b3b71fe44ca4eb8e29cb181d3a0858b3e2a643a55f7513d901bcae",
       "inputs": Array [

--- a/src/__test__/tests/transactions.query.test.ts
+++ b/src/__test__/tests/transactions.query.test.ts
@@ -25,12 +25,13 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
     it('Can return ordered by block index', async () => {
       const result = await client.query({
         query: await loadExampleQueryNode('transactions', 'orderedTransactionsInBlock'),
-        variables: { blockNumber: 4206900 }
+        variables: { blockNumber: 3979532 }
       })
-      expect(result.data.transactions.length).toBe(3)
+      expect(result.data.transactions.length).toBe(8)
       expect(result.data.transactions[0].blockIndex).toBe(0)
       expect(result.data.transactions[1].blockIndex).toBe(1)
       expect(result.data.transactions[2].blockIndex).toBe(2)
+      expect(result.data.transactions[7].blockIndex).toBe(7)
     })
 
     it('Can return aggregated data', async () => {

--- a/src/__test__/tests/transactions.query.test.ts
+++ b/src/__test__/tests/transactions.query.test.ts
@@ -22,6 +22,17 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
       expect(result.data).toMatchSnapshot()
     })
 
+    it('Can return ordered by block index', async () => {
+      const result = await client.query({
+        query: await loadExampleQueryNode('transactions', 'orderedTransactionsInBlock'),
+        variables: { blockNumber: 4206900 }
+      })
+      expect(result.data.transactions.length).toBe(3)
+      expect(result.data.transactions[0].blockIndex).toBe(0)
+      expect(result.data.transactions[1].blockIndex).toBe(1)
+      expect(result.data.transactions[2].blockIndex).toBe(2)
+    })
+
     it('Can return aggregated data', async () => {
       const result = await client.query({
         query: await loadExampleQueryNode('transactions', 'aggregateDataWithinTransaction'),

--- a/src/example_queries/transactions/orderedTransactionsInBlock.graphql
+++ b/src/example_queries/transactions/orderedTransactionsInBlock.graphql
@@ -1,0 +1,14 @@
+query orderedTransactionsInBlock(
+    $blockNumber: Int!
+) {
+    transactions(
+        where: { block: { number: { _eq: $blockNumber }} },
+        order_by: { blockIndex: asc }
+    ) {
+        blockIndex
+        fee
+        hash
+        size
+        totalOutput
+    }
+}

--- a/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
+++ b/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
@@ -8,6 +8,7 @@ query transactionsByHashesOrderByFee(
         block {
             number
         }
+        blockIndex
         fee
         hash
         inputs(order_by: { index: asc }) {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -71,6 +71,7 @@ type Cardano {
 
 type Transaction {
   block: Block
+  blockIndex: Int!
   fee: BigInt!
   hash: Hash32HexString!
   inputs (
@@ -104,6 +105,7 @@ type Transaction {
 
 input Transaction_order_by {
   block: order_by
+  blockIndex: order_by
   fee: order_by
   includedAt: order_by
   size: order_by
@@ -115,6 +117,7 @@ input Transaction_bool_exp {
   _not: Transaction_bool_exp
   _or: [Transaction_bool_exp]
   block: Block_bool_exp
+  blockIndex: Int_comparison_exp
   fee: BigInt_comparison_exp
   hash: Hash32HexString_comparison_exp
   includedAt: Date_comparison_exp


### PR DESCRIPTION
Adds `Transaction.blockIndex`, a missing field surfaced in https://github.com/input-output-hk/cardano-db-sync/issues/91