### PR TITLE
Remove TransactionInput.index and Coin type

### DIFF
--- a/hasura/project/metadata/tables.yaml
+++ b/hasura/project/metadata/tables.yaml
@@ -176,7 +176,6 @@
       - address
       - value
       - txHash
-      - index
       - sourceTxHash
       - sourceTxIndex
       filter: {}

--- a/hasura/project/migrations/1589369664961_init/up.sql
+++ b/hasura/project/migrations/1589369664961_init/up.sql
@@ -75,7 +75,6 @@ select
   source_tx_out.address,
   source_tx_out.value,
   tx.hash as "txHash",
-  tx_out_index as "index",
   source_tx.hash as "sourceTxHash",
   tx_in.tx_out_index as "sourceTxIndex"
 from

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "prestart": "yarn build",
     "start": "HASURA_URI=http://localhost:8090 node dist/index.js",
     "test:tdd": "NODE_ENV=test TEST_MODE=integration jest suite",
-    "test:e2e": "docker-compose up -d && NODE_ENV=test TEST_MODE=e2e jest suite",
-    "test:dataparity": "docker-compose up -d && NODE_ENV=test TEST_MODE=e2e jest dataparity.test",
+    "test:e2e": "docker-compose -f docker-compose.build.yml up -d && NODE_ENV=test TEST_MODE=e2e jest suite",
+    "test:dataparity": "docker-compose up -f docker-compose.build.yml -d && NODE_ENV=test TEST_MODE=e2e jest dataparity.test",
     "loadtest:byron-staging": "artillery run test/loadtest/byron-staging-config.yml"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "codegen:internal": "graphql-codegen",
     "lint": "eslint \"src/**/*.ts\"",
     "dev": "stmux -w always -e ERROR -M -- [[ \"yarn service-dependencies up\" .. \"tsc --watch --noEmit\" .. \"yarn codegen:internal --watch\" ]]",
-    "service-dependencies": "docker-compose config --services | grep -v \"cardano-graphql\" | xargs docker-compose",
+    "service-dependencies": "docker-compose -f docker-compose.build.yml config --services | grep -v \"cardano-graphql\" | xargs docker-compose",
     "test": "HASURA_URI=http://localhost:8090 stmux -w always -e ERROR -M -- [[ \"yarn dev\" .. \"tsc --watch --noEmit\" .. \"yarn test:tdd --watchAll\" ]]",
     "build": "yarn codegen:internal && yarn codegen:external && tsc -p . && shx cp src/schema.graphql dist/ && shx cp -R src/graphql_operations dist/graphql_operations",
     "prestart": "yarn build",

--- a/src/__test__/__snapshots__/suite.test.ts.snap
+++ b/src/__test__/__snapshots__/suite.test.ts.snap
@@ -325,7 +325,8 @@ Object {
       "inputs": Array [
         Object {
           "address": "DdzFFzCqrht5ExAdoZVExXoZTpoMYGKxva3thvvvHapsLZQzSX3kCqwgqi5NSM2oUtHYYDqsSnvSGbqkarB6cSgDZohUhLWZ9KFdDWsa",
-          "index": 0,
+          "sourceTxHash": "f6aa5241cdabb2ca461d1644d56023033b6d32b70afb7a48b224ec3d82ae4a4f",
+          "sourceTxIndex": 0,
           "value": "4924799649906",
         },
       ],
@@ -354,7 +355,8 @@ Object {
       "inputs": Array [
         Object {
           "address": "DdzFFzCqrhsggyaAMAUTjGtjBr1CTp8tTcHYWbqtoyQBZcaYHM16rjbUDawTwoVaEPawAMPLJmpJVXHBNxZnTgmQzqAcNDe6XvMe5BkB",
-          "index": 0,
+          "sourceTxHash": "74a10f4a5de09a393ef8b8f749c50e6938aa4f57908bbdaaefdf5e814fed281a",
+          "sourceTxIndex": 0,
           "value": "768403000000",
         },
       ],

--- a/src/__test__/data_assertions/transaction_assertions.ts
+++ b/src/__test__/data_assertions/transaction_assertions.ts
@@ -19,6 +19,7 @@ export const txe68043 = {
       value: '1000000'
     }],
     size: 216,
+    sourceTxHash: 'f6aa5241cdabb2ca461d1644d56023033b6d32b70afb7a48b224ec3d82ae4a4f',
     totalOutput: '768402828930'
   },
   aggregated: {
@@ -94,6 +95,7 @@ export const tx05ad8b = {
       value: '100000000000'
     }],
     size: 220,
+    sourceTxHash: '74a10f4a5de09a393ef8b8f749c50e6938aa4f57908bbdaaefdf5e814fed281a',
     totalOutput: '4924799478660'
   },
   aggregated: {

--- a/src/__test__/tests/transactions.query.test.ts
+++ b/src/__test__/tests/transactions.query.test.ts
@@ -17,7 +17,8 @@ export function transactionTests (createClient: () => Promise<TestClient>) {
         variables: { hashes: [txe68043.basic.hash, tx05ad8b.basic.hash] }
       })
       expect(result.data.transactions.length).toBe(2)
-      expect(result.data.transactions[0].inputs[0].index).toBe(0)
+      expect(result.data.transactions[0].inputs[0].sourceTxHash).toBe(txe68043.basic.sourceTxHash)
+      expect(result.data.transactions[1].inputs[0].sourceTxHash).toBe(tx05ad8b.basic.sourceTxHash)
       expect(result.data.transactions[0].outputs[0].index).toBe(0)
       expect(result.data).toMatchSnapshot()
     })

--- a/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
+++ b/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
@@ -11,9 +11,10 @@ query transactionsByHashesOrderByFee(
         blockIndex
         fee
         hash
-        inputs(order_by: { index: asc }) {
-            index
+        inputs(order_by: { sourceTxHash: asc }) {
             address
+            sourceTxIndex
+            sourceTxHash
             value
         }
         outputs(order_by: { index: asc }) {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -48,16 +48,16 @@ type Query {
   ): Transaction_aggregate!
   utxos (
     limit: Int
-    order_by: [Utxo_order_by!]
+    order_by: [TransactionOutput_order_by!]
     offset: Int
-    where: Utxo_bool_exp
+    where: TransactionOutput_bool_exp
   ): [TransactionOutput]!
   utxos_aggregate (
     limit: Int
-    order_by: [Utxo_order_by!]
+    order_by: [TransactionOutput_order_by!]
     offset: Int
-    where: Utxo_bool_exp
-  ): Utxo_aggregate!
+    where: TransactionOutput_bool_exp
+  ): TransactionOutput_aggregate!
 }
 
 type Cardano {
@@ -76,28 +76,28 @@ type Transaction {
   hash: Hash32HexString!
   inputs (
     limit: Int
-    order_by: [Coin_order_by]
+    order_by: [TransactionInput_order_by]
     offset: Int
-    where: Coin_bool_exp
+    where: TransactionInput_bool_exp
   ): [TransactionInput!]!
   inputs_aggregate (
     limit: Int
-    order_by: [Coin_order_by]
+    order_by: [TransactionInput_order_by]
     offset: Int
-    where: Coin_bool_exp
-  ): Coin_aggregate
+    where: TransactionInput_bool_exp
+  ): TransactionInput_aggregate
   outputs (
     limit: Int
-    order_by: [Coin_order_by]
+    order_by: [TransactionOutput_order_by]
     offset: Int
-    where: Coin_bool_exp
+    where: TransactionOutput_bool_exp
   ): [TransactionOutput!]!
   outputs_aggregate(
     limit: Int
-    order_by: [Coin_order_by]
+    order_by: [TransactionOutput_order_by]
     offset: Int
-    where: Coin_bool_exp
-  ): Coin_aggregate
+    where: TransactionOutput_bool_exp
+  ): TransactionOutput_aggregate
   size: BigInt!
   totalOutput: String!
   includedAt: DateTime!
@@ -121,8 +121,8 @@ input Transaction_bool_exp {
   fee: BigInt_comparison_exp
   hash: Hash32HexString_comparison_exp
   includedAt: Date_comparison_exp
-  inputs: Coin_bool_exp
-  outputs: Coin_bool_exp
+  inputs: TransactionInput_bool_exp
+  outputs: TransactionOutput_bool_exp
   size: BigInt_comparison_exp
   totalOutput: text_comparison_exp
 }
@@ -167,51 +167,50 @@ type TransactionInput {
   sourceTxHash: Hash32HexString!
   sourceTxIndex: Int!
   address: String!
-  index: Int!
   txHash: Hash32HexString!
   value: String!
 }
 
-input Coin_order_by {
+input TransactionInput_order_by {
   address: order_by
-  index: order_by
+  sourceTxHash: order_by
   txHash: order_by
   value: order_by
 }
 
-input Coin_bool_exp {
-  _and: [Coin_bool_exp]
-  _not: Coin_bool_exp
-  _or: [Coin_bool_exp]
+input TransactionInput_bool_exp {
+  _and: [TransactionInput_bool_exp]
+  _not: TransactionInput_bool_exp
+  _or: [TransactionInput_bool_exp]
   address: text_comparison_exp
   value: text_comparison_exp
 }
 
-type Coin_aggregate {
-  aggregate: Coin_aggregate_fields
+type TransactionInput_aggregate {
+  aggregate: TransactionInput_aggregate_fields
 }
 
-type Coin_aggregate_fields {
-  avg: Coin_avg_fields!
+type TransactionInput_aggregate_fields {
+  avg: TransactionInput_avg_fields!
   count: String!
-  max: Coin_max_fields!
-  min: Coin_min_fields!
-  sum: Coin_sum_fields!
+  max: TransactionInput_max_fields!
+  min: TransactionInput_min_fields!
+  sum: TransactionInput_sum_fields!
 }
 
-type Coin_avg_fields {
+type TransactionInput_avg_fields {
   value: String
 }
 
-type Coin_max_fields {
+type TransactionInput_max_fields {
   value: String
 }
 
-type Coin_min_fields {
+type TransactionInput_min_fields {
   value: String
 }
 
-type Coin_sum_fields {
+type TransactionInput_sum_fields {
   value: String
 }
 
@@ -222,34 +221,48 @@ type TransactionOutput {
   value: String!
 }
 
-type Utxo_aggregate {
-  aggregate: Utxo_aggregate_fields
+input TransactionOutput_order_by {
+  address: order_by
+  index: order_by
+  txHash: order_by
+  value: order_by
 }
 
-type Utxo_aggregate_fields {
-  avg: Uxto_avg_fields!
+input TransactionOutput_bool_exp {
+  _and: [TransactionOutput_bool_exp]
+  _not: TransactionOutput_bool_exp
+  _or: [TransactionOutput_bool_exp]
+  address: text_comparison_exp
+  value: text_comparison_exp
+}
+
+type TransactionOutput_aggregate {
+  aggregate: TransactionOutput_aggregate_fields
+}
+
+type TransactionOutput_aggregate_fields {
+  avg: TransactionOutput_avg_fields!
   count: String!
-  max: Uxto_max_fields!
-  min: Uxto_min_fields!
-  sum: Uxto_sum_fields!
+  max: TransactionOutput_max_fields!
+  min: TransactionOutput_min_fields!
+  sum: TransactionOutput_sum_fields!
 }
 
-type Uxto_avg_fields {
+type TransactionOutput_avg_fields {
   value: String
 }
 
-type Uxto_max_fields {
+type TransactionOutput_max_fields {
   value: String
 }
 
-type Uxto_min_fields {
+type TransactionOutput_min_fields {
   value: String
 }
 
-type Uxto_sum_fields {
+type TransactionOutput_sum_fields {
   value: String
 }
-
 
 type Block {
   createdAt: DateTime!
@@ -415,20 +428,6 @@ type Epoch_sum_fields {
   blocksCount: String!
   output: String!
   transactionsCount: String!
-}
-
-input Utxo_bool_exp {
-  _and: [Utxo_bool_exp]
-  _not: Utxo_bool_exp
-  _or: [Utxo_bool_exp]
-  address: text_comparison_exp
-  value: text_comparison_exp
-}
-
-input Utxo_order_by {
-  address: order_by
-  value: order_by
-  index: order_by
 }
 
 # expression to compare data of type date. All fields are combined with logical 'AND'.


### PR DESCRIPTION
Closes #182 by removing the index field as per discussion in https://github.com/input-output-hk/cardano-db-sync/issues/106

Also removes the additional `Coin` model, as the added abstraction here is unnecessary, and imposes a variation with the Hasura model.