### PR TITLE
adding obj relationship on Utxo to Transaction on txHash=hash.

### DIFF
--- a/hasura/project/metadata/tables.yaml
+++ b/hasura/project/metadata/tables.yaml
@@ -203,6 +203,15 @@
       select_aggregate: utxos_aggregate
       select: utxos
     custom_column_names: {}
+  object_relationships:
+  - name: utxo_tx
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Transaction
+        column_mapping:
+          txHash: hash
   select_permissions:
   - role: cardano-graphql
     permission:

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -218,6 +218,7 @@ type TransactionOutput {
   address: String!
   index: Int!
   txHash: Hash32HexString!
+  utxo_tx: Transaction
   value: String!
 }
 


### PR DESCRIPTION
Certain applications of this repository one to fetch the Block number
of a Utxo along with the Utxo itself.
This is problematic as, to the best of your author's knowledge, there
is no way to do this except by first querying the Utxo, then using its
txHash to query the Transaction.
An unfortunate circumstance as it is, God forbid that one does this
inside of a loop of Utxos!

As far as your author can tell, a Utxo has a logical link to one and
only one transaction, so this unfortunate circumstance can be remedied
simply by making Hasura and company aware of the logical link.
Then one can fetch a the Block.number of a Transaction.hash that matches
one's Utxo.txHash.
Happy days!

Your author would be grateful if a knowledgable expert could correct his
poor understanding of this repository revealed in any mistakes made in
this PR, or else if the same expert could advise on other ways to avoid
the unfortunate circumstance described herein.