### PR TITLE
Set size for docker logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
   cardano-node:
     image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.13.0}
     environment:
@@ -24,7 +29,10 @@ services:
       - node-db:/data/db
       - node-ipc:/ipc
     logging:
-      driver: none
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
   cardano-db-sync-extended:
     image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-2.0.0}
     environment:
@@ -42,6 +50,11 @@ services:
     volumes:
       - node-ipc:/node-ipc
     restart: on-failure
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
   hasura:
     build:
       context: ./hasura
@@ -64,6 +77,11 @@ services:
       - postgres_db
       - postgres_password
       - postgres_user
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
   cardano-graphql:
     build:
       context: .
@@ -76,6 +94,11 @@ services:
       - 3100
     ports:
       - ${API_PORT:-3100}:3100
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
 secrets:
   postgres_db:
     file: ./config/secrets/postgres_db


### PR DESCRIPTION
I am migrating [Adascan.net](https://adascan.net/) to use new graphql api. Last night website died because of docker log file grew to 46G, eating all space on the server. So logs for docker services should be limited by default in docker-compose.yml file  