### PR TITLE
Establish relationships to easily access transaction and block information from inputs and outputs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     stage('Test') {
       steps {
         sh 'docker-compose -p cardano-graphql up --build --force-recreate -d'
-        sh 'echo "Warming up the stack" && sleep 10'
+        sh 'sleep 10'
         sh 'TEST_MODE=e2e yarn test --ci'
       }
       post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
     stage('Test') {
       steps {
         sh 'docker-compose -p cardano-graphql up --build --force-recreate -d'
+        sh 'echo "Warming up the stack" && sleep 10'
         sh 'TEST_MODE=e2e yarn test --ci'
       }
       post {

--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -169,6 +169,23 @@
 - table:
     schema: public
     name: TransactionInput
+  object_relationships:
+  - name: sourceTransaction
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Transaction
+        column_mapping:
+          sourceTxHash: hash
+  - name: transaction
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Transaction
+        column_mapping:
+          txHash: hash
   select_permissions:
   - role: cardano-graphql
     permission:
@@ -184,6 +201,15 @@
 - table:
     schema: public
     name: TransactionOutput
+  object_relationships:
+  - name: transaction
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Transaction
+        column_mapping:
+          txHash: hash
   select_permissions:
   - role: cardano-graphql
     permission:
@@ -203,6 +229,15 @@
       select_aggregate: utxos_aggregate
       select: utxos
     custom_column_names: {}
+  object_relationships:
+  - name: transaction
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Transaction
+        column_mapping:
+          txHash: hash
   select_permissions:
   - role: cardano-graphql
     permission:

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -164,9 +164,11 @@ type Transaction_sum_fields {
 }
 
 type TransactionInput {
+  address: String!
+  sourceTransaction: Transaction!
   sourceTxHash: Hash32HexString!
   sourceTxIndex: Int!
-  address: String!
+  transaction: Transaction!
   txHash: Hash32HexString!
   value: String!
 }
@@ -183,6 +185,8 @@ input TransactionInput_bool_exp {
   _not: TransactionInput_bool_exp
   _or: [TransactionInput_bool_exp]
   address: text_comparison_exp
+  sourceTransaction: Transaction_bool_exp
+  transaction: Transaction_bool_exp
   value: text_comparison_exp
 }
 
@@ -217,6 +221,7 @@ type TransactionInput_sum_fields {
 type TransactionOutput {
   address: String!
   index: Int!
+  transaction: Transaction!
   txHash: Hash32HexString!
   value: String!
 }
@@ -233,6 +238,7 @@ input TransactionOutput_bool_exp {
   _not: TransactionOutput_bool_exp
   _or: [TransactionOutput_bool_exp]
   address: text_comparison_exp
+  transaction: Transaction_bool_exp
   value: text_comparison_exp
 }
 

--- a/packages/api-cardano-db-hasura/src/example_queries/utxos/utxoSetForAddress.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/utxos/utxoSetForAddress.graphql
@@ -6,6 +6,11 @@ query utxoSetForAddress (
         where: { address: { _eq: $address }}
     ) {
         address
+        transaction {
+            block {
+                number
+            }
+        }
         value
     }
 }

--- a/packages/api-cardano-db-hasura/test/blocks.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/blocks.query.test.ts
@@ -1,11 +1,10 @@
 import path from 'path'
-
 import { DocumentNode } from 'graphql'
-import util from '@cardano-graphql/util'
-import utilDev, { TestClient } from '@cardano-graphql/util-dev'
-import { buildSchema } from '../src'
-import { block29021, block29022 } from './data_assertions'
 import gql from 'graphql-tag'
+import util from '@cardano-graphql/util'
+import { TestClient } from '@cardano-graphql/util-dev'
+import { block29021, block29022 } from './data_assertions'
+import { buildClient } from './util'
 
 function loadQueryNode (name: string): Promise<DocumentNode> {
   return util.loadQueryNode(path.resolve(__dirname, '..', 'src', 'example_queries', 'blocks'), name)
@@ -14,12 +13,7 @@ function loadQueryNode (name: string): Promise<DocumentNode> {
 describe('blocks', () => {
   let client: TestClient
   beforeAll(async () => {
-    if (process.env.TEST_MODE === 'e2e') {
-      client = await utilDev.createE2EClient()
-    } else {
-      const schema = await buildSchema('http://localhost:8090')
-      client = await utilDev.createIntegrationClient(schema)
-    }
+    client = await buildClient()
   }, 60000)
 
   it('caps the response to 100 blocks', async () => {

--- a/packages/api-cardano-db-hasura/test/cardano.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/cardano.query.test.ts
@@ -2,8 +2,8 @@ import path from 'path'
 
 import { DocumentNode } from 'graphql'
 import util from '@cardano-graphql/util'
-import utilDev, { TestClient } from '@cardano-graphql/util-dev'
-import { buildSchema } from '../src'
+import { TestClient } from '@cardano-graphql/util-dev'
+import { buildClient } from './util'
 
 function loadQueryNode (name: string): Promise<DocumentNode> {
   return util.loadQueryNode(path.resolve(__dirname, '..', 'src', 'example_queries', 'cardano'), name)
@@ -12,12 +12,7 @@ function loadQueryNode (name: string): Promise<DocumentNode> {
 describe('cardano', () => {
   let client: TestClient
   beforeAll(async () => {
-    if (process.env.TEST_MODE === 'e2e') {
-      client = await utilDev.createE2EClient()
-    } else {
-      const schema = await buildSchema('http://localhost:8090')
-      client = await utilDev.createIntegrationClient(schema)
-    }
+    client = await buildClient()
   }, 60000)
 
   it('Returns static information about the network', async () => {

--- a/packages/api-cardano-db-hasura/test/epochs.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/epochs.query.test.ts
@@ -3,9 +3,9 @@ import path from 'path'
 
 import { DocumentNode } from 'graphql'
 import util from '@cardano-graphql/util'
-import utilDev, { TestClient } from '@cardano-graphql/util-dev'
+import { TestClient } from '@cardano-graphql/util-dev'
 import { epoch1 } from './data_assertions'
-import { buildSchema } from '../src'
+import { buildClient } from './util'
 
 function loadQueryNode (name: string): Promise<DocumentNode> {
   return util.loadQueryNode(path.resolve(__dirname, '..', 'src', 'example_queries', 'epochs'), name)
@@ -14,12 +14,7 @@ function loadQueryNode (name: string): Promise<DocumentNode> {
 describe('epochs', () => {
   let client: TestClient
   beforeAll(async () => {
-    if (process.env.TEST_MODE === 'e2e') {
-      client = await utilDev.createE2EClient()
-    } else {
-      const schema = await buildSchema('http://localhost:8090')
-      client = await utilDev.createIntegrationClient(schema)
-    }
+    client = await buildClient()
   }, 60000)
 
   it('Returns epoch details by number', async () => {

--- a/packages/api-cardano-db-hasura/test/graphql_operations/getAnyUtxoAddress.graphql
+++ b/packages/api-cardano-db-hasura/test/graphql_operations/getAnyUtxoAddress.graphql
@@ -1,0 +1,7 @@
+query getAnyUtxoAddress (
+    $qty: Int!
+){
+    utxos (limit: $qty, where: { transaction: { block: { number: { _is_null: false }}}}) {
+        address
+    }
+}

--- a/packages/api-cardano-db-hasura/test/transactions.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/transactions.query.test.ts
@@ -3,9 +3,9 @@ import path from 'path'
 
 import { DocumentNode } from 'graphql'
 import util from '@cardano-graphql/util'
-import utilDev, { TestClient } from '@cardano-graphql/util-dev'
+import { TestClient } from '@cardano-graphql/util-dev'
 import { tx05ad8b, txe68043 } from './data_assertions'
-import { buildSchema } from '@src/index'
+import { buildClient } from './util'
 
 function loadQueryNode (name: string): Promise<DocumentNode> {
   return util.loadQueryNode(path.resolve(__dirname, '..', 'src', 'example_queries', 'transactions'), name)
@@ -14,12 +14,7 @@ function loadQueryNode (name: string): Promise<DocumentNode> {
 describe('transactions', () => {
   let client: TestClient
   beforeAll(async () => {
-    if (process.env.TEST_MODE === 'e2e') {
-      client = await utilDev.createE2EClient()
-    } else {
-      const schema = await buildSchema('http://localhost:8090')
-      client = await utilDev.createIntegrationClient(schema)
-    }
+    client = await buildClient()
   }, 60000)
 
   it('Returns transactions by hashes', async () => {

--- a/packages/api-cardano-db-hasura/test/util.ts
+++ b/packages/api-cardano-db-hasura/test/util.ts
@@ -1,0 +1,11 @@
+import utilDev from '@cardano-graphql/util-dev'
+import { buildSchema } from '@src/executableSchema'
+
+export async function buildClient () {
+  if (process.env.TEST_MODE === 'e2e') {
+    return utilDev.createE2EClient()
+  } else {
+    const schema = await buildSchema('http://localhost:8090')
+    return utilDev.createIntegrationClient(schema)
+  }
+}

--- a/packages/api-cardano-db-hasura/test/utxos.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/utxos.query.test.ts
@@ -2,8 +2,8 @@ import path from 'path'
 
 import { DocumentNode } from 'graphql'
 import util from '@cardano-graphql/util'
-import utilDev, { TestClient } from '@cardano-graphql/util-dev'
-import { buildSchema } from '@src/index'
+import { TestClient } from '@cardano-graphql/util-dev'
+import { buildClient } from './util'
 
 function loadQueryNode (name: string): Promise<DocumentNode> {
   return util.loadQueryNode(path.resolve(__dirname, '..', 'src', 'example_queries', 'utxos'), name)
@@ -16,12 +16,7 @@ function loadTestOperationDocument (name: string): Promise<DocumentNode> {
 describe('utxos', () => {
   let client: TestClient
   beforeAll(async () => {
-    if (process.env.TEST_MODE === 'e2e') {
-      client = await utilDev.createE2EClient()
-    } else {
-      const schema = await buildSchema('http://localhost:8090')
-      client = await utilDev.createIntegrationClient(schema)
-    }
+    client = await buildClient()
   }, 60000)
 
   it('Can be scoped by address', async () => {

--- a/packages/cli/test/util.ts
+++ b/packages/cli/test/util.ts
@@ -7,7 +7,7 @@ export function setup (done: DoneCallback) {
     const yarnAddGlobal = spawn('yarn', ['add-global'])
     yarnAddGlobal.stderr.on('error', (error) => done(error))
     yarnAddGlobal.on('close', done)
-  }, 4000)
+  }, 6000)
 }
 
 export function teardown (done?: DoneCallback) {


### PR DESCRIPTION
Reimplements #196 due to master branch divergence, which supersedes #195 (Thanks @mebassett)

Includes:
- input -> transaction
- input -> source transaction (where it was an output)
- output -> transaction

**_and_** expressions to use in filtering and sorting.

