### PR TITLE
Localise devDeps required by npm scripts

### DIFF
--- a/packages/api-cardano-db-hasura/package.json
+++ b/packages/api-cardano-db-hasura/package.json
@@ -46,6 +46,12 @@
     "p-retry": "^4.2.0"
   },
   "devDependencies": {
-    "@cardano-graphql/util-dev": "1.0.0-rc.12"
+    "@cardano-graphql/util-dev": "1.0.0-rc.12",
+    "@graphql-codegen/cli": "^1.15.2",
+    "@graphql-codegen/typescript": "^1.15.2",
+    "@graphql-codegen/typescript-graphql-files-modules": "^1.15.2",
+    "@graphql-codegen/typescript-resolvers": "^1.15.2",
+    "@types/node": "^14.0.13",
+    "typescript": "^3.9.5"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,6 +59,9 @@
     "ts-log": "^2.1.4",
     "write-json-file": "^4.3.0"
   },
+  "devDependencies": {
+    "typescript": "^3.9.5"
+  },
   "directories": {
     "lib": "src",
     "test": "test"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,10 @@
     "ts-custom-error": "^3.1.1"
   },
   "devDependencies": {
-    "@cardano-graphql/util-dev": "1.0.0-rc.12"
+    "@cardano-graphql/util-dev": "1.0.0-rc.12",
+    "@types/graphql-depth-limit": "^1.1.2",
+    "@types/node": "^14.0.13",
+    "typescript": "^3.9.5"
   },
   "directories": {
     "lib": "src",

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -20,10 +20,8 @@
     "url": "https://github.com/input-output-hk/cardano-graphql/issues"
   },
   "homepage": "https://github.com/input-output-hk/cardano-graphql/blob/master/packages/util-dev/README.md",
-  "dependencies": {
-    "graphql": "14.5.8",
-    "graphql-tag": "^2.10.3",
-    "p-retry": "^4.2.0"
+  "devDependencies": {
+    "@cardano-graphql/util": "1.0.0-rc.12"
   },
   "directories": {
     "lib": "src",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -25,6 +25,10 @@
     "graphql-tag": "^2.10.3",
     "p-retry": "^4.2.0"
   },
+  "devDependencies": {
+    "@types/node": "^14.0.13",
+    "typescript": "^3.9.5"
+  },
   "directories": {
     "lib": "src",
     "test": "test"


### PR DESCRIPTION
This is only needed for this implementation of yarn2nix, as yarn workspaces symlinks the bins usually.