### PR TITLE
Fix/retain ci test stack between runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,11 +27,6 @@ pipeline {
         sh 'sleep 10'
         sh 'TEST_MODE=e2e yarn test --ci'
       }
-      post {
-        always {
-          sh 'docker-compose -p cardano-graphql down'
-        }
-      }
     }
     stage('Publish: Git Revision') {
       steps {

--- a/packages/api-cardano-db-hasura/hasura/docker-entrypoint.sh
+++ b/packages/api-cardano-db-hasura/hasura/docker-entrypoint.sh
@@ -8,7 +8,8 @@ POSTGRES_USER=${POSTGRES_USER:-$(cat ${SECRET_DIR}/postgres_user)}
 POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-$(cat ${SECRET_DIR}/postgres_password)}
 HASURA_GRAPHQL_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
-
+echo "Sleeping to ensure migrations are applied after db-sync starts"
+sleep 15
 /bin/pre-start.sh \
   --db-url ${HASURA_GRAPHQL_DATABASE_URL} \
   --hasura-cli-path /bin/hasura-cli \

--- a/packages/util-dev/src/e2e_client.ts
+++ b/packages/util-dev/src/e2e_client.ts
@@ -20,17 +20,17 @@ export const createE2EClient = async () => {
     })
   })
   await pRetry(async () => {
-    await client.query({
+    const result = await client.query({
       query: gql`query {
-          cardano {
-              tip { 
-                  number
-              }
-              currentEpoch {
-                  number
-              }
+          cardanoDbMeta {
+              initialized
+              slotDiffFromNetworkTip
+              syncPercentage
           }}`
     })
+    if (result.data?.cardanoDbMeta.initialized === false) {
+      throw new Error(`Cardano DB is not initialized: ${JSON.stringify(result.data)}`)
+    }
   }, {
     factor: 1.75,
     retries: 9,


### PR DESCRIPTION
- Keep the stack running between test runs
- Use the new `cardanoDbMeta` query to determine readiness