### PR TITLE
Version 2.0.0-beta.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       context: ./packages/api-cardano-db-hasura/hasura
     image: inputoutput/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-1.0.0}
     ports:
-      - "8090:8080"
+      - ${HASURA_PORT:-8090}:8080
     depends_on:
       - "postgres"
     restart: on-failure
@@ -90,6 +90,7 @@ services:
     image: inputoutput/cardano-graphql:${CARDANO_GRAPHQL_VERSION:-1.0.0}
     environment:
       - CACHE_ENABLED=true
+      - GENESIS_FILE_BYRON=/configuration/genesis_byron.json
       - GENESIS_FILE_SHELLEY=/configuration/genesis_shelley.json
       - HASURA_URI=http://hasura:8080
       - POSTGRES_HOST=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   hasura:
     build:
       context: ./packages/api-cardano-db-hasura/hasura
-    image: inputoutput/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-1.0.0}
+    image: inputoutput/cardano-graphql-hasura:${CARDANO_GRAPHQL_VERSION:-2.0.0-beta.0}
     ports:
       - ${HASURA_PORT:-8090}:8080
     depends_on:
@@ -87,7 +87,7 @@ services:
     build:
       context: .
       target: server
-    image: inputoutput/cardano-graphql:${CARDANO_GRAPHQL_VERSION:-1.0.0}
+    image: inputoutput/cardano-graphql:${CARDANO_GRAPHQL_VERSION:-2.0.0-beta.0}
     environment:
       - CACHE_ENABLED=true
       - GENESIS_FILE_BYRON=/configuration/genesis_byron.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cardano-graphql",
   "description": "A TypeScript monorepo. Includes a server package and API modules for flexible implementation",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "service-dependencies": "docker-compose config --services | grep -v \"cardano-graphql\" | xargs docker-compose",
     "start:mainnet": "GENESIS_FILE_BYRON=${PWD}/config/network/mainnet/genesis_byron.json GENESIS_FILE_SHELLEY=${PWD}/config/network/mainnet/genesis_shelley.json HASURA_URI=http://localhost:8090 yarn workspace @cardano-graphql/server start",
     "start:shelley_testnet": "GENESIS_FILE_SHELLEY=${PWD}/config/network/shelley_testnet/genesis_shelley.json yarn workspace @cardano-graphql/server start",
-    "start:mainnet_candidate_3": "GENESIS_FILE_BYRON=${PWD}/config/network/mainnet_candidate_3/genesis_byron.json GENESIS_FILE_SHELLEY=${PWD}/config/network/mainnet_candidate_3/genesis_shelley.json yarn workspace @cardano-graphql/server start",
+    "start:mainnet_candidate_3": "GENESIS_FILE_BYRON=${PWD}/config/network/mainnet_candidate_3/genesis_byron.json GENESIS_FILE_SHELLEY=${PWD}/config/network/mainnet_candidate_3/genesis_shelley.json HASURA_URI=http://localhost:8090 yarn workspace @cardano-graphql/server start",
     "test": "yarn workspaces run test"
   },
   "contributors": [

--- a/packages/api-cardano-db-hasura/package.json
+++ b/packages/api-cardano-db-hasura/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-graphql/api-cardano-db-hasura",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "Module for interfacing with the Cardano DB, populated by cardano-db-sync-extended that utilises Hasura for a powerful query interface",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,7 +32,7 @@
     "schema.graphql"
   ],
   "dependencies": {
-    "@cardano-graphql/util": "1.0.0",
+    "@cardano-graphql/util": "2.0.0-beta.0",
     "@graphql-tools/delegate": "^6.0.10",
     "@graphql-tools/schema": "^6.0.9",
     "@graphql-tools/wrap": "^6.0.9",
@@ -50,7 +50,7 @@
     "set-interval-async": "^1.0.33"
   },
   "devDependencies": {
-    "@cardano-graphql/util-dev": "1.0.0",
+    "@cardano-graphql/util-dev": "2.0.0-beta.0",
     "@graphql-codegen/cli": "^1.15.2",
     "@graphql-codegen/typescript": "^1.15.2",
     "@graphql-codegen/typescript-graphql-files-modules": "^1.15.2",

--- a/packages/api-genesis/README.md
+++ b/packages/api-genesis/README.md
@@ -1,3 +1,3 @@
 # Cardano GraphQL - API Genesis
 
-This API module provides access to the network's genesis file.
+This API module provides access to the network's genesis files, keyed by era.

--- a/packages/api-genesis/package.json
+++ b/packages/api-genesis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-graphql/api-genesis",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "Query the network genesis",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,7 +38,7 @@
     "graphql-scalars": "^1.2.2"
   },
   "devDependencies": {
-    "@cardano-graphql/util-dev": "1.0.0",
+    "@cardano-graphql/util-dev": "2.0.0-beta.0",
     "@graphql-codegen/cli": "^1.15.2",
     "@graphql-codegen/typescript": "^1.15.2",
     "@graphql-codegen/typescript-graphql-files-modules": "^1.15.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-graphql/cli",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "Management tool for managing a Cardano GraphQL deployment",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/client-ts/package.json
+++ b/packages/client-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-graphql/client-ts",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "A client package for Cardano GraphQL, including the GraphQL schema and TypeScript definitions generated from it",
   "repository": {
     "type": "git",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-graphql/server",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "Serve the Cardano GraphQL API over HTTP",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/input-output-hk/cardano-graphql/blob/master/packages/server/README.md",
   "dependencies": {
-    "@cardano-graphql/api-cardano-db-hasura": "1.0.0",
-    "@cardano-graphql/api-genesis": "1.0.0",
+    "@cardano-graphql/api-cardano-db-hasura": "2.0.0-beta.0",
+    "@cardano-graphql/api-genesis": "2.0.0-beta.0",
     "@graphql-tools/merge": "^6.0.10",
     "apollo-metrics": "^1.0.1",
     "apollo-server-core": "^2.14.3",
@@ -39,7 +39,7 @@
     "ts-custom-error": "^3.1.1"
   },
   "devDependencies": {
-    "@cardano-graphql/util-dev": "1.0.0",
+    "@cardano-graphql/util-dev": "2.0.0-beta.0",
     "@types/graphql-depth-limit": "^1.1.2",
     "@types/node": "^14.0.13",
     "shx": "^0.3.2",

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-graphql/util-dev",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "Common development utilities",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/input-output-hk/cardano-graphql/blob/master/packages/util-dev/README.md",
   "devDependencies": {
-    "@cardano-graphql/util": "1.0.0",
+    "@cardano-graphql/util": "2.0.0-beta.0",
     "shx": "^0.3.2"
   },
   "directories": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardano-graphql/util",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "Common utilities",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Closes #24 
Closes #205 
Closes #223

```
PASS test/transactions.query.test.ts (9.165 s)
PASS test/blocks.query.test.ts (9.164 s)
PASS test/epochs.query.test.ts (9.764 s)
PASS test/cardano.query.test.ts
PASS test/utxos.query.test.ts (25.784 s)
Test Suites: 5 passed, 5 total
Tests:       21 passed, 21 total
Snapshots:   13 passed, 13 total
Time:        36.323 s
```
```
PASS test/Server.test.ts (29.109 s)
  Server
    Whitelisting
      Booting the server without providing a whitelist
        ✓ returns data for all valid queries (98 ms)
      Providing a whitelist produced by persistgraphql, intended to limit the API for specific application requirements
        ✓ Accepts listed queries (14186 ms)
        ✓ Returns a networkError if a valid but unlisted operation is sent (10470 ms)
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        29.58 s
```
```
PASS test/cli.test.ts (18.177 s)
  CLI Test
    ✓ Shows the program help if no arguments are passed (401 ms)
    system-info command
      ✓ Logs an object useful during issue reporting (355 ms)
    docker command
      ✓ Shows the program help if no arguments are passed (680 ms)
      init
        ✓ writes a config file to the appropriate platform-specific path, scoped by command, copies a docker compose file to use as boilerplate, and handles secret generation (799 ms)
        ✓ can be used in automated processes using command arguments (739 ms)
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   3 passed, 3 total
Time:        18.901 s
```