### PR TITLE
Chore/cardano db sync 3.1.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This version is required for transitioning through the upcoming Shelley hard for
 ### Compatible with:
 
 - [`cardano-node`: `1.18.0`](https://github.com/input-output-hk/cardano-node/releases/tag/1.18.0)
-- [`cardano-db-sync`: `3.0.0`](https://github.com/input-output-hk/cardano-db-sync/releases/tag/3.0.0) - Note: The database must be recreated using the new version.
+- [`cardano-db-sync`: `3.1.0`](https://github.com/input-output-hk/cardano-db-sync/releases/tag/3.1.0) - Note: The database must be recreated using the new version.
 
 ## Features
 ### New Queries
@@ -41,17 +41,17 @@ configuration if required is a good strategy. Simply copying the top level `conf
 - `cardanoDbSync.slotDiffFromNetworkTip` **removed** in reponse to a change in strategy for determining 
 sync status with `cardano-db-sync` determining sync status relies on a chain
 that has produce
-- `Block.slotWithinEpoch` **removed** due to complexity with variation across eras. The Genesis API has information
-for calculations based on context.
 
 ### Changed fields
 Dates we're previously formatted to ISO 3339, however ISO 8601 is being adopted with this release for 
 alignment with the Shelley genesis file format and simplification when the precision is not required. 
 - `2017-10-03T21:43:51.000Z` -> `2017-10-03T21:43:51Z` 
-- `Block.createdAt` -> `Block.forgedAt`
 - `Block.createdBy` -> `Block.slotLeader` links to an object, with a nullable `stakePool` field. For 
 previous behaviour, `Block.slotLeader.description` can be used, however the description prefixes have
 changed upstream from `SlotLeader` to `ByronGenesis`
+- `Block.createdAt` -> `Block.forgedAt`
+- `Block.slotWithinEpoch` -> `Block.slotInEpoch`
+
 
 ## Chores
 - Migrations have been squashed into a single step.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
         max-size: "400k"
         max-file: "20"
   cardano-db-sync-extended:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-3.0.0}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-3.1.0}
     command: [
       "--config", "/config/config.json",
       "--socket-path", "/node-ipc/node.socket"

--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -63,6 +63,7 @@
       - previousBlockHash
       - protocolVersion
       - size
+      - slotInEpoch
       - slotNo
       - transactionsCount
       - vrfKey

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -13,6 +13,7 @@ CREATE VIEW "Block" AS
     block.tx_count AS "transactionsCount",
     block.epoch_no AS "epochNo",
     block."time" AS "forgedAt",
+    block.epoch_slot_no AS "slotInEpoch",
     block.slot_no AS "slotNo",
     slot_leader.id AS "slot_leader_id",
     block.vrf_key As "vrfKey"

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -570,6 +570,7 @@ type Block {
   merkelRoot: Hash32HexString
   number: Int
   opCert: Hash32HexString
+  slotInEpoch: Int
   # Ouroboros Classic Epoch Boundary blocks (EBB) do not have a slot number
   slotNo: Int
   # Ouroboros Classic Epoch Boundary blocks (EBB) do not have a slot number
@@ -606,6 +607,7 @@ input Block_bool_exp {
   previousBlock: Block_bool_exp
   nextBlock: Block_bool_exp
   size: BigInt_comparison_exp
+  slotInEpoch: Int_comparison_exp
   slotNo: Int_comparison_exp
   transactions: Transaction_bool_exp
   transactionsCount: text_comparison_exp

--- a/packages/api-cardano-db-hasura/src/example_queries/blocks/blocksByHashes.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/blocks/blocksByHashes.graphql
@@ -20,7 +20,9 @@ query blocksByHashes(
         merkelRoot
         number
         forgedAt
-        createdBy
+        slotLeader {
+            description
+        }
         previousBlock {
             hash
             number

--- a/packages/api-cardano-db-hasura/test/data_assertions/block_assertions.ts
+++ b/packages/api-cardano-db-hasura/test/data_assertions/block_assertions.ts
@@ -11,6 +11,7 @@ export const block29021 = {
     forgedAt: '2017-09-30T15:03:11Z',
     createdBy: 'SlotLeader-8e8a7b0f4a23f07a',
     number: 29021,
+    slotInEpoch: 7435,
     slotNo: 29035,
     previousBlock: {
       hash: '663c25ee1434e6d29f8bd08bd52ddbb16a30bb54ca3c69c815e3de7bc4c42770',
@@ -82,6 +83,7 @@ export const block29022 = {
       number: 29023
     },
     size: 631,
+    slotInEpoch: 7436,
     slotNo: 29036,
     transactionsCount: '0'
   }


### PR DESCRIPTION
Updates to `cardano-db-sync@3.1.0`, restoring `Block.slotInEpoch`