### PR TITLE
nixos: POSTGRES_PORT to string

### DIFF
--- a/nix/nixos/cardano-graphql-service.nix
+++ b/nix/nixos/cardano-graphql-service.nix
@@ -134,7 +134,7 @@ in {
         POSTGRES_DB = cfg.db;
         POSTGRES_HOST = cfg.dbHost;
         POSTGRES_PASSWORD = cfg.dbPassword;
-        POSTGRES_PORT = cfg.dbPort;
+        POSTGRES_PORT = toString cfg.dbPort;
         POSTGRES_USER = cfg.dbUser;
         PROMETHEUS_METRICS = boolToNodeJSEnv cfg.enablePrometheus;
         TRACING = boolToNodeJSEnv (cfg.enableTracing || cfg.enablePrometheus);


### PR DESCRIPTION
We need `POSTGRES_PORT` as a string.