### PR TITLE
nixos service: fix database credentials to work correctly

### DIFF
--- a/nix/nixos/cardano-graphql-service.nix
+++ b/nix/nixos/cardano-graphql-service.nix
@@ -11,11 +11,12 @@ in {
 
       dbHost = lib.mkOption {
         type = lib.types.str;
-        default = "127.0.0.1";
+        default = "/run/postgresql";
       };
 
       dbPassword = lib.mkOption {
         type = lib.types.str;
+        default = ''""'';
       };
 
       dbPort = lib.mkOption {


### PR DESCRIPTION
Adds defaults (unix socket and pg_hba auth instead of passwords) that match postgres connection pattern used widely throughout nixpkgs nixos modules.