### PR TITLE
fix: add missing GraphQL model for Delegation.transaction

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -138,11 +138,13 @@ type CardanoDbMeta {
 type Delegation {
   address: String!
   stakePool: StakePool!
+  transaction: Transaction
 }
 
 input Delegation_order_by {
   address: text_comparison_exp
   stakePool: StakePool_order_by
+  transaction: Transaction_order_by
 }
 
 input Delegation_bool_exp {
@@ -151,6 +153,7 @@ input Delegation_bool_exp {
   _or: [Delegation_bool_exp]
   address: text_comparison_exp
   stakePool: StakePool_bool_exp
+  transaction: Transaction_bool_exp
 }
 
 type Delegation_aggregate {

--- a/packages/api-cardano-db-hasura/src/example_queries/delegations/delegationSample.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/delegations/delegationSample.graphql
@@ -7,5 +7,12 @@ query delegationSample (
         stakePool {
             hash
         }
+        transaction {
+            fee
+            totalOutput
+            block {
+                number
+            }
+        }
     }
 }

--- a/packages/api-cardano-db-hasura/test/delegations.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/delegations.query.test.ts
@@ -25,6 +25,7 @@ describe('delegations', () => {
     expect(delegations.length).toBe(5)
     expect(delegations[0].address.slice(0, 5)).toBe('stake')
     expect(delegations[0].stakePool.hash).toBeDefined()
+    expect(delegations[0].transaction.block.number).toBeDefined()
   })
 
   it('can return aggregated data on all delegations', async () => {


### PR DESCRIPTION
Hasura is configured with the transaction relationship, however it is not defined in the GraphQL APIs