### PR TITLE
feat: Add build arg to include genesis files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf -L https://github.com/hasura/graphql-en
 RUN hasura --skip-update-check update-cli --version v1.2.1
 
 FROM frolvlad/alpine-glibc:alpine-3.11_glibc-2.30 as server
+ARG NETWORK=mainnet
 RUN apk add nodejs
 RUN mkdir /application
 COPY --from=builder /application/packages/api-cardano-db-hasura/dist /application/packages/api-cardano-db-hasura/dist
@@ -48,6 +49,7 @@ COPY --from=builder /application/packages/util/dist /application/packages/util/d
 COPY --from=builder /application/packages/util/package.json /application/packages/util/package.json
 COPY --from=production_deps /application/node_modules /application/node_modules
 COPY --from=downloader /usr/local/bin/hasura /usr/local/bin/hasura
+COPY config/network/${NETWORK}/genesis /config/genesis/
 WORKDIR /application/packages/server/dist
 EXPOSE 3100
 CMD ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,12 +101,14 @@ services:
     build:
       context: .
       target: server
+      args:
+        - NETWORK=${NETWORK:-mainnet}
     image: inputoutput/cardano-graphql:${CARDANO_GRAPHQL_VERSION:-2.0.0}
     environment:
       - ALLOW_INTROSPECTION=true
       - CACHE_ENABLED=true
-      - GENESIS_FILE_BYRON=/genesis/byron.json
-      - GENESIS_FILE_SHELLEY=/genesis/shelley.json
+      - GENESIS_FILE_BYRON=/config/genesis/byron.json
+      - GENESIS_FILE_SHELLEY=/config/genesis/shelley.json
       - HASURA_URI=http://hasura:8080
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
@@ -127,8 +129,6 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-    volumes:
-      - ./config/network/${NETWORK:-mainnet}/genesis:/genesis
 secrets:
   postgres_db:
     file: ./config/secrets/postgres_db


### PR DESCRIPTION
# Context

Closes #260 

# Proposed Solution
- Add Dockerfile build `ARG`, defaulting to `mainnet`

# Important Changes Introduced
- Mounting genesis files for `mainnet` or `testnet` is now a build time concern, although custom network config can still be mounted at runtime.
- Genesis files are now nested in a top level `config` dir in the container
