### PR TITLE
Chore/cardano db sync 5.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         max-size: "200k"
         max-file: "10"
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.19.0}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.19.1}
     command: [
       "run",
       "--config", "/config/config.json",
@@ -44,7 +44,7 @@ services:
         max-size: "400k"
         max-file: "20"
   cardano-db-sync-extended:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-4.0.0}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-master}
     command: [
       "--config", "/config/config.json",
       "--socket-path", "/node-ipc/node.socket"

--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -261,7 +261,7 @@
           schema: public
           name: pool_owner
         column_mapping:
-          id: pool_id
+          id: pool_hash_id
   - name: relays
     using:
       manual_configuration:
@@ -521,7 +521,7 @@
           schema: public
           name: StakePool
         column_mapping:
-          pool_id: id
+          pool_hash_id: id
   select_permissions:
   - role: cardano-graphql
     permission:

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/down.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/down.sql
@@ -1,4 +1,4 @@
-DROP VIEW if EXISTS
+DROP VIEW IF EXISTS
   "Block",
   "Cardano",
   "Delegation",
@@ -14,4 +14,9 @@ DROP VIEW if EXISTS
   "TransactionOutput",
   "Utxo",
   "Withdrawal" CASCADE;
+DROP INDEX IF EXISTS
+  idx_block_hash,
+  idx_tx_hash,
+  idx_tx_in_consuming_tx,
+  idx_tx_out_tx;
 DROP FUNCTION IF EXISTS utxo_set_at_block CASCADE;

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -43,7 +43,7 @@ SELECT
 FROM
   delegation
 LEFT OUTER JOIN pool_hash
-  ON delegation.pool_id = pool_hash.id;
+  ON delegation.pool_hash_id = pool_hash.id;
 
 CREATE VIEW "Epoch" AS
 SELECT

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -197,6 +197,18 @@ SELECT
   withdrawal.tx_id AS "tx_id"
 FROM withdrawal;
 
+CREATE INDEX idx_block_hash
+    ON block(hash);
+
+CREATE INDEX idx_tx_hash
+    ON tx(hash);
+
+ CREATE INDEX idx_tx_in_consuming_tx
+    ON tx_in(tx_out_id);
+
+CREATE INDEX idx_tx_out_tx
+    ON tx_out(tx_id);
+
 CREATE function utxo_set_at_block("hash" hash32type)
 RETURNS SETOF "TransactionOutput" AS $$
   SELECT
@@ -215,3 +227,4 @@ RETURNS SETOF "TransactionOutput" AS $$
   WHERE tx_in.tx_in_id IS NULL
   AND tx.block <= (SELECT id FROM block WHERE hash = "hash")
 $$ LANGUAGE SQL stable;
+


### PR DESCRIPTION
The current state is targeting `4.0.0`. Upstream indices have also been dropped.

# Proposed Solution
Updates to the `cardano-db-sync` RC, and adopts orphaned indices from https://github.com/input-output-hk/cardano-db-sync/pull/261


# Important Changes Introduced
- Requires db rebuild
- Targets `cardano-node@1.19.1`


