### PR TITLE
fix: scope allow list to graphql path

### DIFF
--- a/packages/server/src/express_middleware/allow_list.ts
+++ b/packages/server/src/express_middleware/allow_list.ts
@@ -1,9 +1,9 @@
 import express from 'express'
 
-export function allowListMiddleware (allowList: {[key: string]: number }) {
+export function allowListMiddleware (allowList: {[key: string]: number }, graphqlPath = '/') {
   return (request: express.Request, response: express.Response, next: Function) => {
-    if (allowList[request.body.query] === undefined) {
-      response.sendStatus(403)
+    if (request.path === graphqlPath && allowList[request.body.query] === undefined) {
+      return response.sendStatus(403)
     }
     next()
   }


### PR DESCRIPTION
# Context
Closes #303
# Proposed Solution
Scope the allow list logic to the graphql path to so that the metrics endpoint isn't impacted by the allow-list logic

