### PR TITLE
feat(api-cardano-db-hasura): add Transaction.deposit

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -393,6 +393,7 @@
       columns:
       - blockHash
       - blockIndex
+      - deposit
       - fee
       - hash
       - includedAt

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -134,6 +134,7 @@ CREATE VIEW "Transaction" AS
 SELECT
   block.hash AS "blockHash",
   tx.block_index AS "blockIndex",
+  tx.deposit AS "deposit",
   COALESCE(tx.fee, 0) AS fee,
   tx.hash,
   tx.id,

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -343,6 +343,7 @@ type StakeRegistration_aggregate_fields {
 type Transaction {
   block: Block
   blockIndex: Int!
+  deposit: BigInt!
   fee: BigInt!
   hash: Hash32HexString!
   inputs (
@@ -377,6 +378,7 @@ type Transaction {
 input Transaction_order_by {
   block: order_by
   blockIndex: order_by
+  deposit: order_by
   fee: order_by
   includedAt: order_by
   size: order_by
@@ -389,6 +391,7 @@ input Transaction_bool_exp {
   _or: [Transaction_bool_exp]
   block: Block_bool_exp
   blockIndex: Int_comparison_exp
+  deposit: BigInt_comparison_exp
   fee: BigInt_comparison_exp
   hash: Hash32HexString_comparison_exp
   includedAt: Date_comparison_exp
@@ -411,24 +414,28 @@ type Transaction_aggregate_fields {
 }
 
 type Transaction_avg_fields {
+  deposit: Float
   fee: Float
   size: Float
   totalOutput: Float
 }
 
 type Transaction_max_fields {
+  deposit: String
   fee: String
   size: String
   totalOutput: String
 }
 
 type Transaction_min_fields {
+  deposit: String
   fee: String
   size: String
   totalOutput: String
 }
 
 type Transaction_sum_fields {
+  deposit: String
   fee: String
   size: String
   totalOutput: String

--- a/packages/api-cardano-db-hasura/src/example_queries/blocks/aggregateDataWithinBlock.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/blocks/aggregateDataWithinBlock.graphql
@@ -36,6 +36,7 @@ query aggregatedDataWithinBlock (
                     totalOutput
                 }
                 sum {
+                    deposit
                     fee
                     size
                     totalOutput

--- a/packages/api-cardano-db-hasura/src/example_queries/transactions/aggregateDataWithinTransaction.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/transactions/aggregateDataWithinTransaction.graphql
@@ -5,6 +5,7 @@ query aggregatedDataWithinTransaction(
         where: { hash: { _in: $hashes }},
         order_by: { fee: desc }
     ) {
+        deposit
         fee
         hash
         inputs_aggregate {

--- a/packages/api-cardano-db-hasura/src/example_queries/transactions/orderedTransactionsInBlock.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/transactions/orderedTransactionsInBlock.graphql
@@ -6,6 +6,7 @@ query orderedTransactionsInBlock(
         order_by: { blockIndex: asc }
     ) {
         blockIndex
+        deposit
         fee
         hash
         size

--- a/packages/api-cardano-db-hasura/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
@@ -9,6 +9,7 @@ query transactionsByHashesOrderByFee(
             number
         }
         blockIndex
+        deposit
         fee
         hash
         inputs(order_by: { sourceTxHash: asc }) {

--- a/packages/api-cardano-db-hasura/test/__snapshots__/blocks.query.test.ts.snap
+++ b/packages/api-cardano-db-hasura/test/__snapshots__/blocks.query.test.ts.snap
@@ -24,6 +24,7 @@ Object {
             "totalOutput": "768402828930",
           },
           "sum": Object {
+            "deposit": "0",
             "fee": "342316",
             "size": "436",
             "totalOutput": "5693202307590",

--- a/packages/api-cardano-db-hasura/test/__snapshots__/transactions.query.test.ts.snap
+++ b/packages/api-cardano-db-hasura/test/__snapshots__/transactions.query.test.ts.snap
@@ -4,6 +4,7 @@ exports[`transactions Can return aggregated data 1`] = `
 Object {
   "transactions": Array [
     Object {
+      "deposit": 0,
       "fee": 171246,
       "hash": "05ad8b467095e0886713a38231ab9fe84e4031a433a9400ebf70ec9415e20102",
       "inputs_aggregate": Object {
@@ -42,6 +43,7 @@ Object {
       },
     },
     Object {
+      "deposit": 0,
       "fee": 171070,
       "hash": "e680432562b3b71fe44ca4eb8e29cb181d3a0858b3e2a643a55f7513d901bcae",
       "inputs_aggregate": Object {
@@ -111,6 +113,7 @@ Object {
         "number": 29021,
       },
       "blockIndex": 0,
+      "deposit": 0,
       "fee": 171246,
       "hash": "05ad8b467095e0886713a38231ab9fe84e4031a433a9400ebf70ec9415e20102",
       "inputs": Array [
@@ -141,6 +144,7 @@ Object {
         "number": 29021,
       },
       "blockIndex": 1,
+      "deposit": 0,
       "fee": 171070,
       "hash": "e680432562b3b71fe44ca4eb8e29cb181d3a0858b3e2a643a55f7513d901bcae",
       "inputs": Array [

--- a/packages/api-cardano-db-hasura/test/data_assertions/block_assertions.ts
+++ b/packages/api-cardano-db-hasura/test/data_assertions/block_assertions.ts
@@ -45,6 +45,7 @@ export const block29021 = {
           totalOutput: '768402828930'
         },
         sum: {
+          deposit: '0',
           fee: '342316',
           size: '436',
           totalOutput: '5693202307590'

--- a/packages/api-cardano-db-hasura/test/data_assertions/transaction_assertions.ts
+++ b/packages/api-cardano-db-hasura/test/data_assertions/transaction_assertions.ts
@@ -4,6 +4,7 @@ export const txe68043 = {
     block: {
       number: 29021
     },
+    deposit: 0,
     fee: 171070,
     hash: 'e680432562b3b71fe44ca4eb8e29cb181d3a0858b3e2a643a55f7513d901bcae',
     includedAt: '2017-09-30T15:03:11Z',
@@ -23,6 +24,7 @@ export const txe68043 = {
     totalOutput: '768402828930'
   },
   aggregated: {
+    deposit: 0,
     fee: 171070,
     hash: 'e680432562b3b71fe44ca4eb8e29cb181d3a0858b3e2a643a55f7513d901bcae',
     inputs_aggregate: {
@@ -80,6 +82,7 @@ export const tx05ad8b = {
     block: {
       number: 29021
     },
+    deposit: 0,
     fee: 171246,
     hash: '05ad8b467095e0886713a38231ab9fe84e4031a433a9400ebf70ec9415e20102',
     includedAt: '2017-09-30T15:03:11Z',
@@ -99,6 +102,7 @@ export const tx05ad8b = {
     totalOutput: '4924799478660'
   },
   aggregated: {
+    deposit: 0,
     fee: 171246,
     hash: '05ad8b467095e0886713a38231ab9fe84e4031a433a9400ebf70ec9415e20102',
     inputs_aggregate: {


### PR DESCRIPTION
# Context
Transaction deposits were added to the `cardano-db-sync` schema
# Proposed Solution
Maps the column through to a field `Transaction.deposit`, and includes relevant filtering options

