### PR TITLE
feat(api-cardano-db-hasura): add Epoch.fees

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -156,12 +156,13 @@
   - role: cardano-graphql
     permission:
       columns:
-      - output
-      - number
-      - transactionsCount
-      - startedAt
-      - lastBlockTime
       - blocksCount
+      - fees
+      - lastBlockTime
+      - number
+      - output
+      - startedAt
+      - transactionsCount
       filter: {}
       limit: 100
       allow_aggregations: true

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -47,6 +47,7 @@ LEFT OUTER JOIN pool_hash
 
 CREATE VIEW "Epoch" AS
 SELECT
+  epoch.fees AS "fees",
   epoch.out_sum AS "output",
   epoch.no AS "number",
   epoch.tx_count AS "transactionsCount",

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -664,6 +664,7 @@ type Epoch {
     where: Block_bool_exp
   ): Block_aggregate!
   blocksCount: String!
+  fees: BigInt!
   output: String!
   number: Int!
   transactionsCount: String!
@@ -677,6 +678,7 @@ input Epoch_bool_exp {
   _or: [Epoch_bool_exp]
   blocks: Block_bool_exp
   blocksCount: text_comparison_exp
+  fees: BigInt_comparison_exp
   number: Int_comparison_exp
   output: text_comparison_exp
   transactionsCount: text_comparison_exp
@@ -684,6 +686,7 @@ input Epoch_bool_exp {
 
 input Epoch_order_by {
   blocksCount: order_by
+  fees: order_by
   number: order_by
   output: order_by
   transactionsCount: order_by
@@ -702,6 +705,7 @@ type Epoch_aggregate_fields {
 
 type Epoch_max_fields {
   blocksCount: String!
+  fees: String!
   number: Int!
   output: String!
   transactionsCount: String!
@@ -709,12 +713,14 @@ type Epoch_max_fields {
 
 type Epoch_min_fields {
   blocksCount: String!
+  fees: String!
   output: String!
   transactionsCount: String!
 }
 
 type Epoch_sum_fields {
   blocksCount: String!
+  fees: String!
   output: String!
   transactionsCount: String!
 }

--- a/packages/api-cardano-db-hasura/src/example_queries/epochs/aggregateDataWithinEpoch.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/epochs/aggregateDataWithinEpoch.graphql
@@ -24,6 +24,7 @@ query aggregatedDataWithinEpoch (
                 }
             }
         }
+        fees
         number
     }
 }

--- a/packages/api-cardano-db-hasura/src/example_queries/epochs/epochDetailsByNumber.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/epochs/epochDetailsByNumber.graphql
@@ -3,6 +3,7 @@ query epochDetailsByNumber (
 ){
     epochs( where: { number: { _eq: $number }}) {
         blocksCount
+        fees
         output
         number
         transactionsCount

--- a/packages/api-cardano-db-hasura/src/example_queries/epochs/epochDetailsInRange.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/epochs/epochDetailsInRange.graphql
@@ -3,6 +3,7 @@ query epochDetailsInRange (
 ) {
     epochs( where: { number: { _in: $numbers }}) {
         blocksCount
+        fees
         output
         number
         transactionsCount

--- a/packages/api-cardano-db-hasura/src/example_queries/epochs/numberOfBlocksProducedByLeaderInEpoch.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/epochs/numberOfBlocksProducedByLeaderInEpoch.graphql
@@ -13,6 +13,7 @@ query numberOfBlocksProducedByLeaderInEpoch (
                 count
             }
         }
+        fees
         number
     }
 }

--- a/packages/api-cardano-db-hasura/test/__snapshots__/epochs.query.test.ts.snap
+++ b/packages/api-cardano-db-hasura/test/__snapshots__/epochs.query.test.ts.snap
@@ -49,6 +49,7 @@ Object {
           },
         },
       },
+      "fees": 1033002678,
       "number": 1,
     },
   ],
@@ -64,6 +65,7 @@ Object {
           "count": "3123",
         },
       },
+      "fees": 1033002678,
       "number": 1,
     },
   ],
@@ -75,6 +77,7 @@ Object {
   "epochs": Array [
     Object {
       "blocksCount": "21590",
+      "fees": 1033002678,
       "lastBlockTime": "2017-10-03T21:44:31Z",
       "number": 1,
       "output": "101402912214214220",
@@ -90,6 +93,7 @@ Object {
   "epochs": Array [
     Object {
       "blocksCount": "21590",
+      "fees": 1033002678,
       "lastBlockTime": "2017-10-03T21:44:31Z",
       "number": 1,
       "output": "101402912214214220",

--- a/packages/api-cardano-db-hasura/test/data_assertions/epoch_assertions.ts
+++ b/packages/api-cardano-db-hasura/test/data_assertions/epoch_assertions.ts
@@ -2,6 +2,7 @@ export const epoch1 = {
   basic: {
     startedAt: '2017-09-28T21:44:51Z',
     blocksCount: '21590',
+    fees: 1033002678,
     lastBlockTime: '2017-10-03T21:44:31Z',
     output: '101402912214214220',
     number: 1,
@@ -30,6 +31,7 @@ export const epoch1 = {
         }
       }
     },
+    fees: 1033002678,
     number: 1
   }
 }


### PR DESCRIPTION
# Context
Epoch fees were added to the `cardano-db-sync` schema
# Proposed Solution
Maps the column through to a field `Epoch.fees`, and includes relevant filtering options

