### PR TITLE
chore/cardano db sync 5.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         max-size: "400k"
         max-file: "20"
   cardano-db-sync-extended:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-master}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-5.0.0}
     command: [
       "--config", "/config/config.json",
       "--socket-path", "/node-ipc/node.socket"

--- a/packages/api-cardano-db-hasura/src/HasuraClient.ts
+++ b/packages/api-cardano-db-hasura/src/HasuraClient.ts
@@ -68,11 +68,24 @@ export class HasuraClient {
         throw error
       }
     }
-
-    return wrapSchema({
+    const coreTypes = [
+      'Block',
+      'Cardano',
+      'Epoch',
+      'Block',
+      'Transaction'
+    ]
+    const schema = wrapSchema({
       schema: await introspectSchema(executor),
       executor
     })
+    for (const t of coreTypes) {
+      const gqlType = schema.getType(t)
+      if (!gqlType) {
+        throw new Error(`Remote schema is missing ${t}`)
+      }
+    }
+    return schema
   }
 
   public async getMeta () {


### PR DESCRIPTION
# Context
Currently pinning `master` in the docker-compose file. There's also a race condition that's causing intermittent failures on startup
# Proposed Solution
Updates to `cardano-db-sync@5.0.0` , and also fixes #281
