### PR TITLE
fix: include @types/* packages in workspace devDependencies

### DIFF
--- a/packages/api-cardano-db-hasura/package.json
+++ b/packages/api-cardano-db-hasura/package.json
@@ -57,6 +57,8 @@
     "@graphql-codegen/typescript-graphql-files-modules": "^1.15.2",
     "@graphql-codegen/typescript-resolvers": "^1.15.2",
     "@types/node": "^14.0.13",
+    "@types/pg": "^7.14.4",
+    "@types/set-interval-async": "^1.0.0",
     "shx": "^0.3.2",
     "typescript": "^3.9.5"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@cardano-graphql/util-dev": "2.0.0",
+    "@types/fs-extra": "^9.0.1",
     "@types/graphql-depth-limit": "^1.1.2",
     "@types/node": "^14.0.13",
     "shx": "^0.3.2",


### PR DESCRIPTION
# Context
When using the api packages in another project, some `@types` packages were missing, and required manual installation.

# Proposed Solution
Adds the missing dev packages to the relevant workspace packages

