### PR TITLE
feat(api-cardano-db-hasura): add Transaction.withdrawals

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -388,6 +388,14 @@
           name: TransactionOutput
         column_mapping:
           hash: txHash
+  - name: withdrawals
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Withdrawal
+        column_mapping:
+          id: tx_id
   select_permissions:
   - role: cardano-graphql
     permission:

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -373,6 +373,13 @@ type Transaction {
   size: BigInt!
   totalOutput: String!
   includedAt: DateTime!
+  withdrawals: [Withdrawal!]
+  withdrawals_aggregate(
+    limit: Int
+    order_by: [Withdrawal_order_by]
+    offset: Int
+    where: Withdrawal_bool_exp
+  ): Withdrawal_aggregate!
 }
 
 input Transaction_order_by {
@@ -380,9 +387,11 @@ input Transaction_order_by {
   blockIndex: order_by
   deposit: order_by
   fee: order_by
+  hash: order_by
   includedAt: order_by
   size: order_by
   totalOutput: order_by
+  withdrawals: order_by
 }
 
 input Transaction_bool_exp {
@@ -399,6 +408,7 @@ input Transaction_bool_exp {
   outputs: TransactionOutput_bool_exp
   size: BigInt_comparison_exp
   totalOutput: text_comparison_exp
+  withdrawals: Withdrawal_bool_exp
 }
 
 type Transaction_aggregate {
@@ -418,6 +428,7 @@ type Transaction_avg_fields {
   fee: Float
   size: Float
   totalOutput: Float
+  withdrawals: Withdrawal_ave_fields
 }
 
 type Transaction_max_fields {
@@ -425,6 +436,7 @@ type Transaction_max_fields {
   fee: String
   size: String
   totalOutput: String
+  withdrawals: Withdrawal_max_fields
 }
 
 type Transaction_min_fields {
@@ -432,6 +444,7 @@ type Transaction_min_fields {
   fee: String
   size: String
   totalOutput: String
+  withdrawals: Withdrawal_min_fields
 }
 
 type Transaction_sum_fields {
@@ -439,6 +452,7 @@ type Transaction_sum_fields {
   fee: String
   size: String
   totalOutput: String
+  withdrawals: Withdrawal_sum_fields
 }
 
 type TransactionInput {
@@ -612,6 +626,7 @@ input Block_order_by {
   slotLeader: order_by
   epoch: Epoch_order_by
   fees: order_by
+  hash: order_by
   number: order_by_with_nulls
   size: order_by
   slotNo: order_by_with_nulls
@@ -752,21 +767,26 @@ type Withdrawal_aggregate {
 
 type Withdrawal_aggregate_fields {
   count: String!
+  ave: Withdrawal_ave_fields!
   max: Withdrawal_max_fields!
   min: Withdrawal_min_fields!
   sum: Withdrawal_sum_fields!
 }
 
+type Withdrawal_ave_fields {
+  amount: String
+}
+
 type Withdrawal_max_fields {
-  amount: String!
+  amount: String
 }
 
 type Withdrawal_min_fields {
-  amount: String!
+  amount: String
 }
 
 type Withdrawal_sum_fields {
-  amount: String!
+  amount: String
 }
 
 # expression to compare data of type date. All fields are combined with logical 'AND'.

--- a/packages/api-cardano-db-hasura/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
@@ -1,9 +1,9 @@
-query transactionsByHashesOrderByFee(
+query transactionsByHashes(
     $hashes: [Hash32HexString]!
 ) {
     transactions(
         where: { hash: { _in: $hashes }},
-        order_by: { fee: desc }
+        order_by: { hash: desc }
     ) {
         block {
             number
@@ -18,12 +18,33 @@ query transactionsByHashesOrderByFee(
             sourceTxHash
             value
         }
+        inputs_aggregate {
+            aggregate {
+                sum {
+                    value
+                }
+            }
+        }
         outputs(order_by: { index: asc }) {
             index
             address
             value
         }
+        outputs_aggregate {
+            aggregate {
+                sum {
+                    value
+                }
+            }
+        }
         size
         totalOutput
+        withdrawals_aggregate {
+            aggregate {
+                sum {
+                    amount
+                }
+            }
+        }
     }
 }

--- a/packages/api-cardano-db-hasura/test/__snapshots__/transactions.query.test.ts.snap
+++ b/packages/api-cardano-db-hasura/test/__snapshots__/transactions.query.test.ts.snap
@@ -112,37 +112,6 @@ Object {
       "block": Object {
         "number": 29021,
       },
-      "blockIndex": 0,
-      "deposit": 0,
-      "fee": 171246,
-      "hash": "05ad8b467095e0886713a38231ab9fe84e4031a433a9400ebf70ec9415e20102",
-      "inputs": Array [
-        Object {
-          "address": "DdzFFzCqrht5ExAdoZVExXoZTpoMYGKxva3thvvvHapsLZQzSX3kCqwgqi5NSM2oUtHYYDqsSnvSGbqkarB6cSgDZohUhLWZ9KFdDWsa",
-          "sourceTxHash": "f6aa5241cdabb2ca461d1644d56023033b6d32b70afb7a48b224ec3d82ae4a4f",
-          "sourceTxIndex": 0,
-          "value": "4924799649906",
-        },
-      ],
-      "outputs": Array [
-        Object {
-          "address": "DdzFFzCqrhsxVv8Sjuj35Zkw42T9WjwXa6DasrNknm5M3bPVDnWJWwhX5NymoZncUArTfFYZ9sYGaA9htKSNYoK5Vkzx2vUtunAFt3eE",
-          "index": 0,
-          "value": "4824799478660",
-        },
-        Object {
-          "address": "DdzFFzCqrhskotfhVwhLvNFaVGpA6C4yR9DXe56oEL4Ewmze51f1uQsc1cQb8qUyqgzjUPBgFZiVbuQu7BaXrQkouyvzjYjLqfJpKG5s",
-          "index": 1,
-          "value": "100000000000",
-        },
-      ],
-      "size": 220,
-      "totalOutput": "4924799478660",
-    },
-    Object {
-      "block": Object {
-        "number": 29021,
-      },
       "blockIndex": 1,
       "deposit": 0,
       "fee": 171070,
@@ -155,6 +124,13 @@ Object {
           "value": "768403000000",
         },
       ],
+      "inputs_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "value": "768403000000",
+          },
+        },
+      },
       "outputs": Array [
         Object {
           "address": "DdzFFzCqrhsuz652nVpjktdtiV44uWJLHv83m61S33gzfB4TBx7SKp3DgM18fBJznMrbUdsEFEvXW4LYqVKFE9fjMgVhmJP2LBhUvEe8",
@@ -167,8 +143,126 @@ Object {
           "value": "1000000",
         },
       ],
+      "outputs_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "value": "768402828930",
+          },
+        },
+      },
       "size": 216,
       "totalOutput": "768402828930",
+      "withdrawals_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "amount": null,
+          },
+        },
+      },
+    },
+    Object {
+      "block": Object {
+        "number": 4603616,
+      },
+      "blockIndex": 0,
+      "deposit": 0,
+      "fee": 175225,
+      "hash": "0b8c5be678209bb051a02904dd18896a929f9aca8aecd48850939a590175f7e8",
+      "inputs": Array [
+        Object {
+          "address": "addr1qyenqkgd5rjzfj4x66kgpw7xctald54swmxscgt26y0jyx9ms7x7wfk2xmekqj76value5k8ppjggssnkvpwal0cyq9qtf3dp7",
+          "sourceTxHash": "264a68d3be10af40fc51419fa53362835259816cfb3b1ca6459b8ec951c2c659",
+          "sourceTxIndex": 0,
+          "value": "3920534466",
+        },
+      ],
+      "inputs_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "value": "3920534466",
+          },
+        },
+      },
+      "outputs": Array [
+        Object {
+          "address": "addr1qy2d6t0rw32wu9yxhwx3a9hzt7tzwysy4ymlk6nh62f45z9ms7x7wfk2xmekqj76value5k8ppjggssnkvpwal0cyq9qmktzym",
+          "index": 0,
+          "value": "4072979066",
+        },
+        Object {
+          "address": "DdzFFzCqrhsvZTcS6vpcdH1Eg1YMFsaRPAyh2EmxbsQfRgBD75UHNHk7sR4vap2FvcUYtLCh5AfgqBdV4FzT5U3uMytB85tXhCaH8xUv",
+          "index": 1,
+          "value": "2000000",
+        },
+      ],
+      "outputs_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "value": "4074979066",
+          },
+        },
+      },
+      "size": 447,
+      "totalOutput": "4074979066",
+      "withdrawals_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "amount": "154619825",
+          },
+        },
+      },
+    },
+    Object {
+      "block": Object {
+        "number": 29021,
+      },
+      "blockIndex": 0,
+      "deposit": 0,
+      "fee": 171246,
+      "hash": "05ad8b467095e0886713a38231ab9fe84e4031a433a9400ebf70ec9415e20102",
+      "inputs": Array [
+        Object {
+          "address": "DdzFFzCqrht5ExAdoZVExXoZTpoMYGKxva3thvvvHapsLZQzSX3kCqwgqi5NSM2oUtHYYDqsSnvSGbqkarB6cSgDZohUhLWZ9KFdDWsa",
+          "sourceTxHash": "f6aa5241cdabb2ca461d1644d56023033b6d32b70afb7a48b224ec3d82ae4a4f",
+          "sourceTxIndex": 0,
+          "value": "4924799649906",
+        },
+      ],
+      "inputs_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "value": "4924799649906",
+          },
+        },
+      },
+      "outputs": Array [
+        Object {
+          "address": "DdzFFzCqrhsxVv8Sjuj35Zkw42T9WjwXa6DasrNknm5M3bPVDnWJWwhX5NymoZncUArTfFYZ9sYGaA9htKSNYoK5Vkzx2vUtunAFt3eE",
+          "index": 0,
+          "value": "4824799478660",
+        },
+        Object {
+          "address": "DdzFFzCqrhskotfhVwhLvNFaVGpA6C4yR9DXe56oEL4Ewmze51f1uQsc1cQb8qUyqgzjUPBgFZiVbuQu7BaXrQkouyvzjYjLqfJpKG5s",
+          "index": 1,
+          "value": "100000000000",
+        },
+      ],
+      "outputs_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "value": "4924799478660",
+          },
+        },
+      },
+      "size": 220,
+      "totalOutput": "4924799478660",
+      "withdrawals_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "amount": null,
+          },
+        },
+      },
     },
   ],
 }

--- a/packages/api-cardano-db-hasura/test/data_assertions/transaction_assertions.ts
+++ b/packages/api-cardano-db-hasura/test/data_assertions/transaction_assertions.ts
@@ -10,6 +10,7 @@ export const txe68043 = {
     includedAt: '2017-09-30T15:03:11Z',
     inputs: [{
       address: 'DdzFFzCqrhsggyaAMAUTjGtjBr1CTp8tTcHYWbqtoyQBZcaYHM16rjbUDawTwoVaEPawAMPLJmpJVXHBNxZnTgmQzqAcNDe6XvMe5BkB',
+      sourceTxHash: '74a10f4a5de09a393ef8b8f749c50e6938aa4f57908bbdaaefdf5e814fed281a',
       value: '768403000000'
     }],
     outputs: [{
@@ -20,7 +21,6 @@ export const txe68043 = {
       value: '1000000'
     }],
     size: 216,
-    sourceTxHash: 'f6aa5241cdabb2ca461d1644d56023033b6d32b70afb7a48b224ec3d82ae4a4f',
     totalOutput: '768402828930'
   },
   aggregated: {
@@ -77,6 +77,57 @@ export const txe68043 = {
   }
 }
 
+export const tx0b8c5b = {
+  basic: {
+    block: {
+      number: 4603616
+    },
+    deposit: 0,
+    fee: 175225,
+    hash: '0b8c5be678209bb051a02904dd18896a929f9aca8aecd48850939a590175f7e8',
+    includedAt: '2020-08-25T06:36:38Z',
+    inputs: [{
+      address: 'addr1qyenqkgd5rjzfj4x66kgpw7xctald54swmxscgt26y0jyx9ms7x7wfk2xmekqj76value5k8ppjggssnkvpwal0cyq9qtf3dp7',
+      sourceTxHash: '',
+      value: '3920534466'
+    }],
+    outputs: [{
+      address: 'addr1qy2d6t0rw32wu9yxhwx3a9hzt7tzwysy4ymlk6nh62f45z9ms7x7wfk2xmekqj76value5k8ppjggssnkvpwal0cyq9qmktzym',
+      value: '4072979066'
+    }, {
+      address: 'DdzFFzCqrhsvZTcS6vpcdH1Eg1YMFsaRPAyh2EmxbsQfRgBD75UHNHk7sR4vap2FvcUYtLCh5AfgqBdV4FzT5U3uMytB85tXhCaH8xUv',
+      value: '2000000'
+    }],
+    size: 447,
+    totalOutput: '4074979066'
+  },
+  aggregated: {
+    hash: '05ad8b467095e0886713a38231ab9fe84e4031a433a9400ebf70ec9415e20102',
+    inputs_aggregate: {
+      sum: {
+        value: '4924799649906'
+      }
+    },
+    outputs_aggregate: {
+      aggregate: {
+        avg: {
+          value: '2462399739330'
+        },
+        count: '2',
+        max: {
+          value: '4824799478660'
+        },
+        min: {
+          value: '100000000000'
+        },
+        sum: {
+          value: '4924799478660'
+        }
+      }
+    }
+  }
+}
+
 export const tx05ad8b = {
   basic: {
     block: {
@@ -88,6 +139,7 @@ export const tx05ad8b = {
     includedAt: '2017-09-30T15:03:11Z',
     inputs: [{
       address: 'DdzFFzCqrht5ExAdoZVExXoZTpoMYGKxva3thvvvHapsLZQzSX3kCqwgqi5NSM2oUtHYYDqsSnvSGbqkarB6cSgDZohUhLWZ9KFdDWsa',
+      sourceTxHash: 'f6aa5241cdabb2ca461d1644d56023033b6d32b70afb7a48b224ec3d82ae4a4f',
       value: '4924799649906'
     }],
     outputs: [{
@@ -98,7 +150,6 @@ export const tx05ad8b = {
       value: '100000000000'
     }],
     size: 220,
-    sourceTxHash: '74a10f4a5de09a393ef8b8f749c50e6938aa4f57908bbdaaefdf5e814fed281a',
     totalOutput: '4924799478660'
   },
   aggregated: {


### PR DESCRIPTION

# Context
Withdrawals are currently disconnected from the context of a Transaction, despite being part of the [Shelley transaction model](https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files/shelley.cddl#L57). It should be natural to implement https://github.com/input-output-hk/cardano-explorer-app/issues/352 
# Proposed Solution
Makes withdrawals and withdrawal aggregate data available from
Transaction, to be easily referenced from the natural context.

# Important Changes Introduced
Also adds hash as a sort option to transactions and blocks.

