### PR TITLE
Added missing port number for relays

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -169,6 +169,7 @@ type Relay {
   ipv6: IPv6
   dnsName: URL
   dnsSrvName: String
+  port: String
 }
 
 input Relay_bool_exp {
@@ -176,6 +177,7 @@ input Relay_bool_exp {
   ipv6: text_comparison_exp
   dnsName: text_comparison_exp
   dnsSrvName: text_comparison_exp
+  port: text_comparison_exp
 }
 
 type StakeDeregistration {


### PR DESCRIPTION
# Context
The stake pool relays are missing the port number.

# Proposed Solution
Added the port number in the graphql schema.

# Important Changes Introduced
N/A: port number is optional
