### PR TITLE
Relay dnsName and dnsSrvName incorrectly labeled, missing port.

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -167,15 +167,17 @@ type Delegation_aggregate_fields {
 type Relay {
   ipv4: IPv4
   ipv6: IPv6
-  dnsName: URL
-  dnsSrvName: String
+  dns_name: URL
+  dns_srv_name: String
+  port: String
 }
 
 input Relay_bool_exp {
   ipv4: text_comparison_exp
   ipv6: text_comparison_exp
-  dnsName: text_comparison_exp
-  dnsSrvName: text_comparison_exp
+  dns_name: text_comparison_exp
+  dns_srv_name: text_comparison_exp
+  port: text_comparison_exp
 }
 
 type StakeDeregistration {


### PR DESCRIPTION
# Context
The relay details are labeled incorrectly. The cardano-db-sync defines them as dns_name and dns_srv_name. The port number has also been forgotten.

# Proposed Solution
Added port and corrected the relay labels. 

# Important Changes Introduced
Will break queries that are currently using dnsName and dnsSrvName as they will no longer exist.
