### PR TITLE
fix: add port and custom column names to pool_relay mapping

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -543,6 +543,11 @@
 - table:
     schema: public
     name: pool_relay
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      dns_srv_name: dnsSrvName
+      dns_name: dnsName
   object_relationships:
   - name: stakePool
     using:

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -169,6 +169,7 @@ type Relay {
   ipv6: IPv6
   dnsName: URL
   dnsSrvName: String
+  port: Int
 }
 
 input Relay_bool_exp {
@@ -176,6 +177,7 @@ input Relay_bool_exp {
   ipv6: text_comparison_exp
   dnsName: text_comparison_exp
   dnsSrvName: text_comparison_exp
+  port: Int_comparison_exp
 }
 
 type StakeDeregistration {


### PR DESCRIPTION
# Context
Fixes #328 #329

# Proposed Solution
Add custom column names to complete the field name mapping, and include `port` in GraphQL schema


