### PR TITLE
Feature/stake distribution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         max-size: "400k"
         max-file: "20"
   cardano-db-sync-extended:
-    image: rhyslbw/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-ae190739cf7696464eca4bf143fcd21207a4109a}
+    image: rhyslbw/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-09205d901ee86299cc68b3a0d0a8feb52489858f}
     command: [
       "--config", "/config/cardano-db-sync/config.json",
       "--socket-path", "/node-ipc/node.socket",

--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -1,5 +1,39 @@
 - table:
     schema: public
+    name: ActiveStake
+  configuration:
+    custom_root_fields:
+      select: activeStake
+    custom_column_names: {}
+  object_relationships:
+  - name: epoch
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Epoch
+        column_mapping:
+          epochNo: number
+  - name: registeredWith
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: StakePool
+        column_mapping:
+          pool_hash: hash
+  select_permissions:
+  - role: cardano-graphql
+    permission:
+      columns:
+      - address
+      - amount
+      - epochNo
+      filter: {}
+      limit: 100
+      allow_aggregations: true
+- table:
+    schema: public
     name: Block
   configuration:
     custom_root_fields:
@@ -144,6 +178,14 @@
       select: epochs
     custom_column_names: {}
   array_relationships:
+  - name: activeStake
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: ActiveStake
+        column_mapping:
+          number: epochNo
   - name: blocks
     using:
       manual_configuration:

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/down.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/down.sql
@@ -1,4 +1,5 @@
 DROP VIEW IF EXISTS
+  "ActiveStake",
   "Block",
   "Cardano",
   "Delegation",

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -130,6 +130,19 @@ SELECT
   stake_registration.tx_id AS "tx_id"
 FROM stake_registration;
 
+CREATE VIEW "ActiveStake" AS
+SELECT
+  (
+  	SELECT stake_address.view
+  	FROM stake_address
+  	WHERE stake_address.id = epoch_stake.addr_id
+  ) AS "address",
+  amount AS "amount",
+  epoch_no as "epochNo",
+  id AS "id",
+  ( SELECT pool_hash.hash_raw FROM pool_hash WHERE pool_hash.id = pool_id ) AS "pool_hash"
+FROM epoch_stake;
+
 CREATE VIEW "Transaction" AS
 SELECT
   block.hash AS "blockHash",

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -11,6 +11,12 @@ scalar Percentage
 scalar URL
 
 type Query {
+  activeStake (
+    limit: Int
+    order_by: [ActiveStake_order_by!]
+    offset: Int
+    where: ActiveStake_bool_exp
+  ): [ActiveStake]!
   blocks (
     limit: Int
     order_by: [Block_order_by!]
@@ -135,6 +141,58 @@ type Query {
     offset: Int
     where: Withdrawal_bool_exp
   ): Withdrawal_aggregate
+}
+
+type ActiveStake {
+  address: String!
+  amount: String!
+  epoch: Epoch
+  epochNo: Int!
+  registeredWith: StakePool!
+}
+
+input ActiveStake_bool_exp {
+  address: text_comparison_exp
+  amount: text_comparison_exp
+  epoch: Epoch_bool_exp
+  epochNo: Int_comparison_exp
+  registeredWith: StakePool_bool_exp
+}
+
+input ActiveStake_order_by {
+  address: order_by
+  amount: order_by
+  epoch: Epoch_order_by
+  epochNo: order_by
+  registeredWith: StakePool_order_by
+}
+
+type ActiveStake_aggregate {
+  aggregate: ActiveStake_aggregate_fields
+}
+
+type ActiveStake_aggregate_fields {
+  avg: ActiveStake_avg_fields!
+  count: String!
+  max: ActiveStake_max_fields!
+  min: ActiveStake_min_fields!
+  sum: ActiveStake_sum_fields!
+}
+
+type ActiveStake_avg_fields {
+  amount: Float
+}
+
+type ActiveStake_max_fields {
+  amount: String
+}
+
+type ActiveStake_min_fields {
+  amount: String
+}
+
+type ActiveStake_sum_fields {
+  amount: String
 }
 
 type Cardano {
@@ -738,8 +796,11 @@ type Block_sum_fields {
 }
 
 type Epoch {
+  activeStake: [ActiveStake]
+  activeStake_aggregate: ActiveStake_aggregate
   blocks (
     limit: Int
+    order_by: [Block_order_by!]
     order_by: [Block_order_by!]
     offset: Int
     where: Block_bool_exp

--- a/packages/api-cardano-db-hasura/src/example_queries/active_stake/activeStakeForAddress.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/active_stake/activeStakeForAddress.graphql
@@ -1,0 +1,16 @@
+query activeStakeForAddress (
+    $limit: Int!
+    $where: ActiveStake_bool_exp
+) {
+    activeStake (limit: $limit, where: $where) {
+        address
+        amount
+        epoch {
+            number
+        }
+        epochNo
+        registeredWith {
+            hash
+        }
+    }
+}

--- a/packages/api-cardano-db-hasura/src/example_queries/epochs/aggregateDataWithinEpoch.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/epochs/aggregateDataWithinEpoch.graphql
@@ -1,8 +1,15 @@
 query aggregatedDataWithinEpoch (
-    $number: Int!
+    $where: Epoch_bool_exp
 ) {
-    epochs( where: { number: { _eq: $number }}) {
+    epochs( where: $where) {
         blocksCount
+        activeStake_aggregate {
+            aggregate {
+                sum {
+                    amount
+                }
+            }
+        }
         blocks_aggregate {
             aggregate {
                 avg {

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -30,6 +30,16 @@ export async function buildSchema (hasuraClient: HasuraClient) {
   return makeExecutableSchema({
     resolvers: Object.assign({}, scalarResolvers, {
       Query: {
+        activeStake: (_root, args, context, info) => {
+          return delegateToSchema({
+            args,
+            context,
+            fieldName: 'activeStake',
+            info,
+            operation: 'query',
+            schema: hasuraSchema
+          })
+        },
         blocks: (_root, args, context, info) => {
           return delegateToSchema({
             args,

--- a/packages/api-cardano-db-hasura/test/__snapshots__/epochs.query.test.ts.snap
+++ b/packages/api-cardano-db-hasura/test/__snapshots__/epochs.query.test.ts.snap
@@ -27,6 +27,13 @@ exports[`epochs Can return aggregated data 1`] = `
 Object {
   "epochs": Array [
     Object {
+      "activeStake_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "amount": null,
+          },
+        },
+      },
       "blocksCount": "21590",
       "blocks_aggregate": Object {
         "aggregate": Object {
@@ -51,6 +58,39 @@ Object {
       },
       "fees": 1033002678,
       "number": 1,
+    },
+    Object {
+      "activeStake_aggregate": Object {
+        "aggregate": Object {
+          "sum": Object {
+            "amount": "15657991508072960",
+          },
+        },
+      },
+      "blocksCount": "21627",
+      "blocks_aggregate": Object {
+        "aggregate": Object {
+          "avg": Object {
+            "fees": 237477.9113145605,
+            "size": 491.35959680029595,
+          },
+          "count": "21627",
+          "max": Object {
+            "fees": "498861647",
+            "size": "19292",
+          },
+          "min": Object {
+            "fees": "0",
+            "size": "3",
+          },
+          "sum": Object {
+            "fees": "5135934788",
+            "size": "10626634",
+          },
+        },
+      },
+      "fees": 5135934788,
+      "number": 220,
     },
   ],
 }

--- a/packages/api-cardano-db-hasura/test/activeStake.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/activeStake.query.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable camelcase */
+import path from 'path'
+
+import { DocumentNode } from 'graphql'
+import util from '@cardano-graphql/util'
+import { TestClient } from '@cardano-graphql/util-dev'
+import { buildClient } from './util'
+
+function loadQueryNode (name: string): Promise<DocumentNode> {
+  return util.loadQueryNode(path.resolve(__dirname, '..', 'src', 'example_queries', 'active_stake'), name)
+}
+
+describe('activeStake', () => {
+  let client: TestClient
+  beforeAll(async () => {
+    client = await buildClient('http://localhost:3100', 'http://localhost:8090', 5442)
+  })
+
+  it('can return active stake snapshots for an address', async () => {
+    const result = await client.query({
+      query: await loadQueryNode('activeStakeForAddress'),
+      variables: { limit: 5, where: { address: { _eq: 'stake1u8atejkgfn8772722rh03lmnxyshvjakk260gfsefamc6sga68ag2' } } }
+    })
+    const { activeStake } = result.data
+    expect(activeStake.length).toBe(5)
+    expect(activeStake[0].amount).toBeDefined()
+    expect(activeStake[0].epochNo).toBeDefined()
+    expect(activeStake[0].registeredWith.hash).toBeDefined()
+  })
+})

--- a/packages/api-cardano-db-hasura/test/data_assertions/epoch_assertions.ts
+++ b/packages/api-cardano-db-hasura/test/data_assertions/epoch_assertions.ts
@@ -1,3 +1,5 @@
+import { Epoch } from '@src/graphql_types'
+
 export const epoch1 = {
   basic: {
     startedAt: '2017-09-28T21:44:51Z',
@@ -10,6 +12,13 @@ export const epoch1 = {
   },
   aggregated: {
     blocksCount: '21590',
+    activeStake_aggregate: {
+      aggregate: {
+        sum: {
+          amount: null
+        }
+      }
+    } as Epoch['activeStake_aggregate'],
     blocks_aggregate: {
       aggregate: {
         avg: {
@@ -33,5 +42,50 @@ export const epoch1 = {
     },
     fees: 1033002678,
     number: 1
+  }
+}
+
+export const epoch220 = {
+  basic: {
+    startedAt: '2017-09-28T21:44:51Z',
+    blocksCount: '21627',
+    fees: 1033002678,
+    lastBlockTime: '2017-10-03T21:44:31Z',
+    output: '101402912214214220',
+    number: 220,
+    transactionsCount: '12870'
+  },
+  aggregated: {
+    activeStake_aggregate: {
+      aggregate: {
+        sum: {
+          amount: '15657991508072960'
+        }
+      }
+    },
+    blocksCount: '21627',
+    blocks_aggregate: {
+      aggregate: {
+        avg: {
+          fees: 237477.9113145605,
+          size: 491.35959680029595
+        },
+        count: '21627',
+        max: {
+          fees: '498861647',
+          size: '19292'
+        },
+        min: {
+          fees: '0',
+          size: '3'
+        },
+        sum: {
+          fees: '5135934788',
+          size: '10626634'
+        }
+      }
+    },
+    fees: 5135934788,
+    number: 220
   }
 }

--- a/packages/api-cardano-db-hasura/test/epochs.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/epochs.query.test.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import { DocumentNode } from 'graphql'
 import util from '@cardano-graphql/util'
 import { TestClient } from '@cardano-graphql/util-dev'
-import { epoch1 } from './data_assertions'
+import { epoch1, epoch220 } from './data_assertions'
 import { buildClient } from './util'
 
 function loadQueryNode (name: string): Promise<DocumentNode> {
@@ -29,9 +29,10 @@ describe('epochs', () => {
   it('Can return aggregated data', async () => {
     const result = await client.query({
       query: await loadQueryNode('aggregateDataWithinEpoch'),
-      variables: { number: 1 }
+      variables: { where: { number: { _in: [1, 220] } } }
     })
     expect(result.data.epochs[0]).toEqual(epoch1.aggregated)
+    expect(result.data.epochs[1]).toEqual(epoch220.aggregated)
     expect(result.data.epochs[0].blocksCount).toEqual(epoch1.aggregated.blocks_aggregate.aggregate.count)
     expect(result.data).toMatchSnapshot()
   })


### PR DESCRIPTION
# Context

`cardano-db-sync` is now syncing the stake snapshots into the db, so this PR extends the API model to include it.

# Proposed Solution
An `ActiveStake` record is a snapshot of the stake linked to a registered stake key, per epoch.
This features adds an `activeStake` query, and extends the `Epoch` type to include
 `activeStake` and `activeStake_aggregate` fields.

# Important Changes Introduced

Based on #334 