### PR TITLE
Feature/Stake Pool ID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
         max-size: "400k"
         max-file: "20"
   cardano-db-sync-extended:
-    image: rhyslbw/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-3e02b9370a122cef068e55ac2887b41acc7587ed}
+    image: rhyslbw/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-ae190739cf7696464eca4bf143fcd21207a4109a}
     command: [
       "--config", "/config/cardano-db-sync/config.json",
       "--socket-path", "/node-ipc/node.socket",

--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -118,7 +118,7 @@
           schema: public
           name: StakePool
         column_mapping:
-          pool_hash: hash
+          pool_hash_id: hash_id
   - name: transaction
     using:
       manual_configuration:
@@ -190,7 +190,7 @@
           schema: public
           name: StakePool
         column_mapping:
-          pool_hash: hash
+          pool_hash_id: hash_id
   select_permissions:
   - role: cardano-graphql
     permission:
@@ -211,7 +211,7 @@
           schema: public
           name: StakePool
         column_mapping:
-          pool_hash: hash
+          pool_hash_id: hash_id
   select_permissions:
   - role: cardano-graphql
     permission:
@@ -271,7 +271,7 @@
           schema: public
           name: pool_owner
         column_mapping:
-          id: pool_hash_id
+          hash_id: pool_hash_id
   - name: relays
     using:
       manual_configuration:
@@ -279,7 +279,7 @@
           schema: public
           name: pool_relay
         column_mapping:
-          id: update_id
+          update_id: update_id
   - name: retirements
     using:
       manual_configuration:
@@ -287,7 +287,7 @@
           schema: public
           name: StakePoolRetirement
         column_mapping:
-          hash: pool_hash
+          hash_id: pool_hash_id
   - name: rewards
     using:
       manual_configuration:
@@ -295,13 +295,14 @@
           schema: public
           name: Reward
         column_mapping:
-          hash: pool_hash
+          hash_id: pool_hash_id
   select_permissions:
   - role: cardano-graphql
     permission:
       columns:
       - fixedCost
       - hash
+      - id
       - margin
       - metadataHash
       - pledge
@@ -337,7 +338,7 @@
           schema: public
           name: StakePool
         column_mapping:
-          pool_hash: hash
+          pool_hash_id: hash_id
   select_permissions:
   - role: cardano-graphql
     permission:
@@ -548,7 +549,7 @@
           schema: public
           name: StakePool
         column_mapping:
-          pool_hash_id: id
+          pool_hash_id: hash_id
   select_permissions:
   - role: cardano-graphql
     permission:
@@ -573,7 +574,7 @@
           schema: public
           name: StakePool
         column_mapping:
-          update_id: id
+          update_id: update_id
   select_permissions:
   - role: cardano-graphql
     permission:

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -39,11 +39,8 @@ SELECT
 	  WHERE stake_address.id = delegation.addr_id
   ) AS "address",
   delegation.tx_id AS "tx_id",
-  pool_hash.hash AS "pool_hash"
-FROM
-  delegation
-LEFT OUTER JOIN pool_hash
-  ON delegation.pool_hash_id = pool_hash.id;
+  pool_hash_id AS "pool_hash_id"
+FROM delegation;
 
 CREATE VIEW "Epoch" AS
 SELECT
@@ -65,7 +62,7 @@ SELECT
 	  WHERE stake_address.id = reward.addr_id
   ) AS "address",
   reward.epoch_no AS "epochNo",
-  ( SELECT pool_hash.hash FROM pool_hash WHERE pool_hash.id = reward.pool_id ) AS "pool_hash"
+  reward.pool_id AS "pool_hash_id"
 FROM reward;
 
 CREATE VIEW "SlotLeader" AS
@@ -73,7 +70,7 @@ SELECT
   slot_leader.hash AS "hash",
   slot_leader.id AS "id",
   slot_leader.description AS "description",
-  ( SELECT pool_hash.hash FROM pool_hash WHERE pool_hash.id = slot_leader.pool_hash_id ) AS "pool_hash"
+  slot_leader.pool_hash_id AS "pool_hash_id"
 FROM slot_leader;
 
 CREATE VIEW "StakeDeregistration" AS
@@ -98,8 +95,10 @@ WITH
 )
 SELECT
   pool.fixed_cost AS "fixedCost",
-  ( SELECT pool_hash.hash FROM pool_hash WHERE pool_hash.id = pool.hash_id ) AS "hash",
-  pool.id AS "id",
+  ( SELECT pool_hash.hash_raw FROM pool_hash WHERE pool_hash.id = pool.hash_id ) AS "hash",
+  ( SELECT pool_hash.view FROM pool_hash WHERE pool_hash.id = pool.hash_id ) AS "id",
+  pool.hash_id AS "hash_id",
+  pool.id AS "update_id",
   pool.margin AS "margin",
   pool_meta_data.hash AS "metadataHash",
   block.block_no AS "blockNo",
@@ -117,7 +116,7 @@ CREATE VIEW "StakePoolRetirement" AS
 SELECT
   retiring_epoch as "inEffectFrom",
   announced_tx_id as "tx_id",
-  ( SELECT pool_hash.hash FROM pool_hash WHERE pool_hash.id = hash_id ) AS "pool_hash"
+  hash_id AS "pool_hash_id"
 FROM pool_retire;
 
 CREATE VIEW "StakeRegistration" AS

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -282,6 +282,7 @@ input SlotLeader_bool_exp {
 type StakePool {
   fixedCost: String!
   hash: Hash32HexString!
+  id: String!
   margin: Float!
   metadataHash: Hash32HexString
   owners: [StakePoolOwner!]!
@@ -304,6 +305,7 @@ type StakePool {
 input StakePool_order_by {
   fixedCost: order_by
   hash: order_by
+  id: order_by
   margin: order_by
   pledge: order_by
   updatedIn: Transaction_order_by
@@ -315,6 +317,7 @@ input StakePool_bool_exp {
   _not: StakePool_bool_exp
   _or: [StakePool_bool_exp]
   hash: Hash32HexString_comparison_exp
+  id: text_comparison_exp
   margin: Float_comparison_exp
   metadataHash: Hash32HexString_comparison_exp
   owners: StakePoolOwner_bool_exp

--- a/packages/api-cardano-db-hasura/src/example_queries/stake_pools/allStakePoolFields.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/stake_pools/allStakePoolFields.graphql
@@ -5,6 +5,7 @@ query allStakePoolFields (
     stakePools (limit: $limit, where: $where) {
         fixedCost
         hash
+        id
         margin
         metadataHash
         owners {

--- a/packages/api-cardano-db-hasura/test/stakePool.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/stakePool.query.test.ts
@@ -25,6 +25,7 @@ describe('stakePools', () => {
     expect(stakePools.length).toBe(5)
     expect(stakePools[0].fixedCost).toBeDefined()
     expect(stakePools[0].hash).toBeDefined()
+    expect(stakePools[0].id.slice(0, 4)).toBe('pool')
     expect(stakePools[0].margin).toBeDefined()
     expect(stakePools[0].metadataHash).toBeDefined()
     expect(stakePools[0].owners).toBeDefined()
@@ -65,6 +66,6 @@ describe('stakePools', () => {
     })
     const { stakePools_aggregate } = result.data
     expect(parseInt(stakePools_aggregate.aggregate.count)).toBeGreaterThan(0)
-    expect(parseInt(stakePools_aggregate.aggregate.count)).toBeLessThan(200)
+    expect(parseInt(stakePools_aggregate.aggregate.count)).toBeLessThan(600)
   })
 })

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -32,8 +32,8 @@ export async function getConfig (): Promise<Config> {
 
   if (!hasuraUri && !genesisFileShelley) {
     throw new MissingConfig(
-      `You have not provided configuration to load an API segment. Either set HASURA_URI or 
-      GENESIS_FILE_SHELLEY and GENESIS_FILE_SHELLEY`
+      `You have not provided configuration to load an API segment. Set HASURA_URI and/or 
+      GENESIS_FILE_BYRON and GENESIS_FILE_SHELLEY`
     )
   }
   if (!postgresDbFile && !postgresDb) {


### PR DESCRIPTION
# Context

`cardano-db-sync` is now storing the bech32 encoded Stake Pool ID, so this PR extends the API model to include it. There are also relationships being established through the raw stake pool hash, which was requiring a JOIN, when the table ID can be used. 

# Proposed Solution
- Add `StakePool.id`
- Refactor the views to relate through the pool_hash.id

