### PR TITLE
fix: Change Block.vrfKey type to String

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -729,7 +729,7 @@ type Block {
     where: Transaction_bool_exp
   ): Transaction_aggregate!
   transactionsCount: String!
-  vrfKey: Hash32HexString
+  vrfKey: String
 }
 
 input Block_bool_exp {
@@ -749,6 +749,7 @@ input Block_bool_exp {
   slotNo: Int_comparison_exp
   transactions: Transaction_bool_exp
   transactionsCount: text_comparison_exp
+  vrfKey: text_comparison_exp
 }
 
 input Block_order_by {
@@ -761,6 +762,7 @@ input Block_order_by {
   size: order_by
   slotNo: order_by_with_nulls
   transactionsCount: order_by
+  vrfKey: order_by_with_nulls
 }
 
 type Block_aggregate {

--- a/packages/api-cardano-db-hasura/src/example_queries/blocks/blockByNumber.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/blocks/blockByNumber.graphql
@@ -1,8 +1,0 @@
-query blockByNumber(
-    $number: Int!
-) {
-    blocks (
-        where: { number: { _eq: $number}}) {
-        hash
-    }
-}

--- a/packages/api-cardano-db-hasura/src/example_queries/blocks/blockByNumbers.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/blocks/blockByNumbers.graphql
@@ -1,0 +1,9 @@
+query blockByNumber(
+    $numbers: [Int!]!
+) {
+    blocks (
+        where: { number: { _in: $numbers}}) {
+        hash
+        vrfKey
+    }
+}

--- a/packages/api-cardano-db-hasura/test/__snapshots__/blocks.query.test.ts.snap
+++ b/packages/api-cardano-db-hasura/test/__snapshots__/blocks.query.test.ts.snap
@@ -41,6 +41,11 @@ Object {
   "blocks": Array [
     Object {
       "hash": "bf13d9a80ad99a4f34edb8a3262dd8120e29bbe182732cd3b00bf3d1bb7c2380",
+      "vrfKey": null,
+    },
+    Object {
+      "hash": "ab1df510b2fc22a2731212937f532894c474ddccf6240047b38b4a3c14c1895c",
+      "vrfKey": "vrf_vk1ytuuajlv7wvxj57qr6j5ycx69l54ks5nzswqwyn4fhhec6dtdjgsqmzku7",
     },
   ],
 }

--- a/packages/api-cardano-db-hasura/test/blocks.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/blocks.query.test.ts
@@ -3,7 +3,7 @@ import { DocumentNode } from 'graphql'
 import gql from 'graphql-tag'
 import util from '@cardano-graphql/util'
 import { TestClient } from '@cardano-graphql/util-dev'
-import { block29021, block29022 } from './data_assertions'
+import { block29021, block29022, block4490600 } from './data_assertions'
 import { buildClient } from './util'
 
 function loadQueryNode (name: string): Promise<DocumentNode> {
@@ -38,11 +38,18 @@ describe('blocks', () => {
 
   it('Can return blocks by number', async () => {
     const result = await client.query({
-      query: await loadQueryNode('blockByNumber'),
-      variables: { number: 29022 }
+      query: await loadQueryNode('blockByNumbers'),
+      variables: { numbers: [29022, 4490600] }
     })
-    expect(result.data.blocks.length).toBe(1)
-    expect(result.data.blocks[0]).toEqual({ hash: block29022.basic.hash })
+    expect(result.data.blocks.length).toBe(2)
+    expect(result.data.blocks[0]).toEqual({
+      hash: block29022.basic.hash,
+      vrfKey: null
+    })
+    expect(result.data.blocks[1]).toEqual({
+      hash: block4490600.basic.hash,
+      vrfKey: block4490600.basic.vrfKey
+    })
     expect(result.data).toMatchSnapshot()
   })
 

--- a/packages/api-cardano-db-hasura/test/data_assertions/block_assertions.ts
+++ b/packages/api-cardano-db-hasura/test/data_assertions/block_assertions.ts
@@ -1,3 +1,4 @@
+import { Block } from '@src/graphql_types'
 
 export const block29021 = {
   basic: {
@@ -88,4 +89,30 @@ export const block29022 = {
     slotNo: 29036,
     transactionsCount: '0'
   }
+}
+
+export const block4490600 = {
+  basic: {
+    epoch: {
+      number: 208
+    },
+    epochNo: 208,
+    fees: 3700733,
+    hash: 'ab1df510b2fc22a2731212937f532894c474ddccf6240047b38b4a3c14c1895c',
+    number: 4490510,
+    forgedAt: '2020-07-29T22:14:51Z',
+    previousBlock: {
+      hash: '02d698482b56b7345e3e0cb8938f6b22f12d1370231457eaa0d991bea3327f5c',
+      number: 4490599
+    },
+    nextBlock: {
+      hash: '9fb51dab84fa0e9ae97c6ee48af4e655a330e25d7b96a236d8684761f54eca75',
+      number: 4490601
+    },
+    size: 14476,
+    slotInEpoch: 1800,
+    slotNo: 4494600,
+    transactionsCount: '17',
+    vrfKey: 'vrf_vk1ytuuajlv7wvxj57qr6j5ycx69l54ks5nzswqwyn4fhhec6dtdjgsqmzku7'
+  } as Partial<Block>
 }


### PR DESCRIPTION
# Context
The hex encoded value for blocl.vrf_key has been replaced with a bech32 encoded, CIP5 compliant string value. Since the old value is no longer stored, a breaking change is unavoidable. 

# Proposed Solution
BREAKING CHANGE: `Block.vrfKey` is now a String not Hash32HexString, to
align with upstream changes in `cardano-db-sync`. 


