### PR TITLE
fix: accurately allocate hashes to 28 byte type

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -2,7 +2,8 @@ schema {
   query: Query
 }
 
-scalar Hash32HexString
+scalar Hash28Hex
+scalar Hash32Hex
 scalar IPv4
 scalar IPv6
 scalar BigInt
@@ -327,22 +328,22 @@ input StakeDeregistration_bool_exp {
 
 type SlotLeader {
   description: String!
-  hash: Hash32HexString!
+  hash: Hash28Hex!
   stakePool: StakePool
 }
 
 input SlotLeader_bool_exp {
   description: text_comparison_exp
-  hash: Hash32HexString_comparison_exp
+  hash: Hash28Hex_comparison_exp
   stakePool: StakePool_bool_exp
 }
 
 type StakePool {
   fixedCost: String!
-  hash: Hash32HexString!
+  hash: Hash28Hex!
   id: String!
   margin: Float!
-  metadataHash: Hash32HexString
+  metadataHash: Hash32Hex
   owners: [StakePoolOwner!]!
   pledge: String!
   relays: [Relay]
@@ -374,10 +375,10 @@ input StakePool_bool_exp {
   _and: [StakePool_bool_exp]
   _not: StakePool_bool_exp
   _or: [StakePool_bool_exp]
-  hash: Hash32HexString_comparison_exp
+  hash: Hash28Hex_comparison_exp
   id: text_comparison_exp
   margin: Float_comparison_exp
-  metadataHash: Hash32HexString_comparison_exp
+  metadataHash: Hash32Hex_comparison_exp
   owners: StakePoolOwner_bool_exp
   pledge: text_comparison_exp
   registrationTransaction: Transaction_bool_exp
@@ -425,7 +426,7 @@ type StakePool_sum_fields {
 }
 
 input StakePoolOwner_bool_exp {
-  hash: Hash32HexString_comparison_exp
+  hash: Hash28Hex_comparison_exp
 }
 
 type StakePoolRetirement {
@@ -440,7 +441,7 @@ input StakePoolRetirement_bool_exp {
 }
 
 type StakePoolOwner {
-  hash: Hash32HexString!
+  hash: Hash28Hex!
 }
 
 
@@ -475,7 +476,7 @@ type Transaction {
   blockIndex: Int!
   deposit: BigInt!
   fee: BigInt!
-  hash: Hash32HexString!
+  hash: Hash32Hex!
   inputs (
     limit: Int
     order_by: [TransactionInput_order_by]
@@ -532,7 +533,7 @@ input Transaction_bool_exp {
   blockIndex: Int_comparison_exp
   deposit: BigInt_comparison_exp
   fee: BigInt_comparison_exp
-  hash: Hash32HexString_comparison_exp
+  hash: Hash32Hex_comparison_exp
   includedAt: Date_comparison_exp
   inputs: TransactionInput_bool_exp
   outputs: TransactionOutput_bool_exp
@@ -588,10 +589,10 @@ type Transaction_sum_fields {
 type TransactionInput {
   address: String!
   sourceTransaction: Transaction!
-  sourceTxHash: Hash32HexString!
+  sourceTxHash: Hash32Hex!
   sourceTxIndex: Int!
   transaction: Transaction!
-  txHash: Hash32HexString!
+  txHash: Hash32Hex!
   value: String!
 }
 
@@ -644,7 +645,7 @@ type TransactionOutput {
   address: String!
   index: Int!
   transaction: Transaction!
-  txHash: Hash32HexString!
+  txHash: Hash32Hex!
   value: String!
 }
 
@@ -703,11 +704,11 @@ type Block {
   fees: BigInt!
   forgedAt: DateTime!
   slotLeader: SlotLeader!
-  hash: Hash32HexString!
+  hash: Hash32Hex!
   # Ouroboros Classic Epoch Boundary blocks (EBB) do not have a block number
-  merkelRoot: Hash32HexString
+  merkelRoot: Hash32Hex
   number: Int
-  opCert: Hash32HexString
+  opCert: Hash32Hex
   slotInEpoch: Int
   # Ouroboros Classic Epoch Boundary blocks (EBB) do not have a slot number
   slotNo: Int
@@ -740,7 +741,7 @@ input Block_bool_exp {
   slotLeader: SlotLeader_bool_exp
   epoch: Epoch_bool_exp
   fees: BigInt_comparison_exp
-  hash: Hash32HexString_comparison_exp
+  hash: Hash32Hex_comparison_exp
   number: Int_comparison_exp
   previousBlock: Block_bool_exp
   nextBlock: Block_bool_exp
@@ -986,11 +987,18 @@ input Percentage_comparison_exp {
 }
 
 # All fields are combined with logical 'AND'.
-input Hash32HexString_comparison_exp {
-  _eq: Hash32HexString
-  _in: [Hash32HexString]
-  _neq: Hash32HexString
-  _nin: [Hash32HexString]
+input Hash28Hex_comparison_exp {
+  _eq: Hash28Hex
+  _in: [Hash28Hex]
+  _neq: Hash28Hex
+  _nin: [Hash28Hex]
+}
+
+input Hash32Hex_comparison_exp {
+  _eq: Hash32Hex
+  _in: [Hash32Hex]
+  _neq: Hash32Hex
+  _nin: [Hash32Hex]
 }
 
 input text_comparison_exp {

--- a/packages/api-cardano-db-hasura/src/example_queries/blocks/blocksByHashes.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/blocks/blocksByHashes.graphql
@@ -1,5 +1,5 @@
 query blocksByHashes(
-    $hashes: [Hash32HexString]!
+    $hashes: [Hash32Hex]!
 )  {
     blocks (
         where: {

--- a/packages/api-cardano-db-hasura/src/example_queries/transactions/aggregateDataWithinTransaction.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/transactions/aggregateDataWithinTransaction.graphql
@@ -1,5 +1,5 @@
 query aggregatedDataWithinTransaction(
-    $hashes: [Hash32HexString]!
+    $hashes: [Hash32Hex]!
 ){
     transactions(
         where: { hash: { _in: $hashes }},

--- a/packages/api-cardano-db-hasura/src/example_queries/transactions/filteredAggregateDataWithinTransaction.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/transactions/filteredAggregateDataWithinTransaction.graphql
@@ -1,5 +1,5 @@
 query filteredAggregatedDataWithinTransaction(
-    $hash: Hash32HexString!
+    $hash: Hash32Hex!
 ){
     transactions(
         where: { hash: { _eq: $hash }}

--- a/packages/api-cardano-db-hasura/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/transactions/transactionsByHashesOrderByFee.graphql
@@ -1,5 +1,5 @@
 query transactionsByHashes(
-    $hashes: [Hash32HexString]!
+    $hashes: [Hash32Hex]!
 ) {
     transactions(
         where: { hash: { _in: $hashes }},

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -12,7 +12,8 @@ import { GraphQLSchema } from 'graphql'
 const GraphQLBigInt = require('graphql-bigint')
 
 export const scalarResolvers = {
-  Hash32HexString: util.scalars.Hash32HexString,
+  Hash28Hex: util.scalars.Hash28Hex,
+  Hash32Hex: util.scalars.Hash32Hex,
   BigInt: GraphQLBigInt,
   DateTime: util.scalars.DateTimeUtcToIso,
   Percentage: util.scalars.Percentage

--- a/packages/api-cardano-db-hasura/test/transactions.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/transactions.query.test.ts
@@ -59,7 +59,7 @@ describe('transactions', () => {
   it('returns an empty array when the transactions has no outputs', async () => {
     const result = await client.query({
       query: gql`query transactionWithNoOutputs(
-          $hash: Hash32HexString!
+          $hash: Hash32Hex!
       ) {
           transactions(
               where: { hash: { _eq: $hash } },

--- a/packages/util/src/scalars/Hash28Hex.ts
+++ b/packages/util/src/scalars/Hash28Hex.ts
@@ -1,8 +1,8 @@
 import { GraphQLError, GraphQLScalarType, Kind } from 'graphql'
 
-export const Hash32HexString = new GraphQLScalarType({
-  name: 'Hash32HexString',
-  description: 'Hex encoded hash32 string, 64 characters',
+export const Hash28Hex = new GraphQLScalarType({
+  name: 'Hash28Hex',
+  description: 'Hex encoded 28 byte hash, 56 characters',
   serialize (value: string) {
     return value.substring(2)
   },
@@ -18,6 +18,6 @@ export const Hash32HexString = new GraphQLScalarType({
 })
 
 function validateInput (input: string) {
-  if (input.length !== 64 && input.length !== 56) throw new GraphQLError(`${input} is not a valid hash`)
+  if (input.length !== 56) throw new GraphQLError(`${input} is not a valid 28 byte hash`)
   return `\\x${input}`
 }

--- a/packages/util/src/scalars/Hash32Hex.ts
+++ b/packages/util/src/scalars/Hash32Hex.ts
@@ -1,0 +1,23 @@
+import { GraphQLError, GraphQLScalarType, Kind } from 'graphql'
+
+export const Hash32Hex = new GraphQLScalarType({
+  name: 'Hash32Hex',
+  description: 'Hex encoded 32 byte, 64 characters',
+  serialize (value: string) {
+    return value.substring(2)
+  },
+  parseValue (value: string) {
+    return validateInput(value)
+  },
+  parseLiteral (ast) {
+    switch (ast.kind) {
+      case Kind.STRING :
+        return validateInput(ast.value)
+    }
+  }
+})
+
+function validateInput (input: string) {
+  if (input.length !== 64) throw new GraphQLError(`${input} is not a valid 32 byte hash`)
+  return `\\x${input}`
+}

--- a/packages/util/src/scalars/index.ts
+++ b/packages/util/src/scalars/index.ts
@@ -1,3 +1,4 @@
 export * from './DateTimeUtcToIso'
-export * from './Hash32HexString'
+export * from './Hash28Hex'
+export * from './Hash32Hex'
 export * from './Percentage'


### PR DESCRIPTION
# Context

Closes #271 

# Proposed Solution
Add a new type for 28 byte hex encoded hashes, refactor the existing to a better name, and revert https://github.com/input-output-hk/cardano-graphql/commit/9e28ffa6686fd28ea72a374c4eb45b0aa7b5efe9

# Important Changes Introduced

**BREAKING CHANGES:**
- `Hash32HexString` -> `Hash32Hex`
- `Hash32HexString_comparison_exp` -> `Hash32Hex_comparison_exp`
- `SlotLeader.hash`, `StakePool.hash`, `StakePoolOwner.hash` are now `Hash28Hex` type
