### PR TITLE
feature: Transaction.metadata

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -476,6 +476,14 @@
           name: TransactionInput
         column_mapping:
           hash: txHash
+  - name: metadata
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: tx_metadata
+        column_mapping:
+          id: tx_id
   - name: outputs
     using:
       manual_configuration:
@@ -665,3 +673,27 @@
       filter: {}
       limit: 100
       allow_aggregations: true
+- table:
+    schema: public
+    name: tx_metadata
+  configuration:
+    custom_root_fields: {}
+    custom_column_names:
+      json: value
+  object_relationships:
+  - name: transaction
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Transaction
+        column_mapping:
+          tx_id: id
+  select_permissions:
+  - role: cardano-graphql
+    permission:
+      columns:
+      - json
+      - key
+      filter: {}
+      limit: 100

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -289,7 +289,7 @@ type Genesis {
 type Relay {
   ipv4: IPv4
   ipv6: IPv6
-  dnsName: URL
+  dnsName: String
   dnsSrvName: String
   port: Int
 }
@@ -583,6 +583,7 @@ type Transaction {
     offset: Int
     where: TransactionInput_bool_exp
   ): TransactionInput_aggregate!
+  metadata: [TransactionMetadata]
   outputs (
     limit: Int
     order_by: [TransactionOutput_order_by]
@@ -630,6 +631,7 @@ input Transaction_bool_exp {
   hash: Hash32Hex_comparison_exp
   includedAt: Date_comparison_exp
   inputs: TransactionInput_bool_exp
+  metadata: TransactionMetadata_bool_exp
   outputs: TransactionOutput_bool_exp
   size: BigInt_comparison_exp
   totalOutput: text_comparison_exp
@@ -733,6 +735,15 @@ type TransactionInput_min_fields {
 
 type TransactionInput_sum_fields {
   value: String
+}
+
+type TransactionMetadata {
+  key: String!
+  value: JSONObject!
+}
+
+input TransactionMetadata_bool_exp {
+  key: text_comparison_exp
 }
 
 type TransactionOutput {

--- a/packages/api-cardano-db-hasura/src/example_queries/transactions/transactionByIdWithMetadataIfPresent.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/transactions/transactionByIdWithMetadataIfPresent.graphql
@@ -1,0 +1,12 @@
+query transactionByIdWithMetadataIfPresent (
+    $hash: Hash32Hex!
+) {
+    transactions(
+        where: { hash: { _eq: $hash } }
+    ) {
+        metadata {
+            key
+            value
+        }
+    }
+}

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -8,8 +8,13 @@ import util from '@cardano-graphql/util'
 import { Resolvers, Genesis } from './graphql_types'
 import { HasuraClient } from './HasuraClient'
 import { GraphQLSchema } from 'graphql'
-import { JSONObjectResolver, TimestampResolver } from 'graphql-scalars'
-
+import {
+  IPv4Resolver,
+  IPv6Resolver,
+  JSONObjectResolver,
+  TimestampResolver,
+  URLResolver
+} from 'graphql-scalars'
 const GraphQLBigInt = require('graphql-bigint')
 
 export const scalarResolvers = {
@@ -17,9 +22,12 @@ export const scalarResolvers = {
   DateTime: util.scalars.DateTimeUtcToIso,
   Hash28Hex: util.scalars.Hash28Hex,
   Hash32Hex: util.scalars.Hash32Hex,
+  IPv4: IPv4Resolver,
+  IPv6: IPv6Resolver,
   JSONObject: JSONObjectResolver,
   Percentage: util.scalars.Percentage,
-  Timestamp: TimestampResolver
+  Timestamp: TimestampResolver,
+  URL: URLResolver
 } as any
 
 export async function buildSchema (hasuraClient: HasuraClient, genesis: Genesis) {

--- a/packages/api-cardano-db-hasura/test/__snapshots__/transactions.query.test.ts.snap
+++ b/packages/api-cardano-db-hasura/test/__snapshots__/transactions.query.test.ts.snap
@@ -105,6 +105,54 @@ Object {
 }
 `;
 
+exports[`transactions Can return transaction metadata if present 1`] = `
+Object {
+  "transactions": Array [
+    Object {
+      "metadata": Array [
+        Object {
+          "key": "0",
+          "value": Object {
+            "La_RepsistancE": "Was here",
+          },
+        },
+        Object {
+          "key": "1",
+          "value": Object {
+            "Choices": Array [
+              Object {
+                "CandidateId": "aaa9503a-6fc5-46ea-9aa0-b4c90f361a4c",
+                "VoteRank": 1,
+                "VoteWeight": 1,
+              },
+              Object {
+                "CandidateId": "8d649c12-936e-46be-b65a-c17f30f59574",
+                "VoteRank": 2,
+                "VoteWeight": 1,
+              },
+              Object {
+                "CandidateId": "81ce7f8e-94c3-4835-91fc-2146d51fa1fc",
+                "VoteRank": 0,
+                "VoteWeight": 0,
+              },
+              Object {
+                "CandidateId": "407540aa-58b5-40ca-b484-f40040eb2990",
+                "VoteRank": 3,
+                "VoteWeight": 1,
+              },
+            ],
+            "NetworkId": "TheRealAdamDean",
+            "ObjectType": "VoteBallot",
+            "ProposalId": "80064c28-1b03-4f1c-abf0-ca8c5a98d5b9",
+            "VoterId": "d990a1e8-cb90-4f59-b5cf-a8b59c9ba8ae",
+          },
+        },
+      ],
+    },
+  ],
+}
+`;
+
 exports[`transactions Returns transactions by hashes 1`] = `
 Object {
   "transactions": Array [

--- a/packages/api-cardano-db-hasura/test/transactions.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/transactions.query.test.ts
@@ -117,4 +117,11 @@ describe('transactions', () => {
     })
     expect(result.data).toMatchSnapshot()
   })
+  it('Can return transaction metadata if present', async () => {
+    const result = await client.query({
+      query: await loadQueryNode('transactionByIdWithMetadataIfPresent'),
+      variables: { hash: 'f910021138e553c65b96cf3e4647927fcd9f634e06544251f83cffb1891876e8' }
+    })
+    expect(result.data).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
# Context

`cardano-db-sync` is now maintaining a table of the transaction metadata, so this PR extends the API model to include it. 

# Proposed Solution
`Transaction.metadata` contains an array of metadata if present in the transaction.

# Important Changes Introduced

