### PR TITLE
chore: Remove depreciated config option WHITELIST_PATH

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -103,17 +103,12 @@ function filterAndTypecastEnvs (env: any) {
     POSTGRES_USER_FILE,
     PROMETHEUS_METRICS,
     QUERY_DEPTH_LIMIT,
-    TRACING,
-    WHITELIST_PATH
+    TRACING
   } = env
-  if (WHITELIST_PATH) {
-    console.warn(`WHITELIST_PATH is deprecated and will be removed in 3.0.0.
-    Please update your configuration to use ALLOW_LIST_PATH instead.`)
-  }
   return {
     allowIntrospection: ALLOW_INTROSPECTION === 'true',
     allowedOrigins: ALLOWED_ORIGINS,
-    allowListPath: ALLOW_LIST_PATH || WHITELIST_PATH,
+    allowListPath: ALLOW_LIST_PATH,
     apiPort: Number(API_PORT),
     cacheEnabled: CACHE_ENABLED === 'true',
     genesis: {

--- a/packages/server/test/Server.test.ts
+++ b/packages/server/test/Server.test.ts
@@ -152,7 +152,7 @@ describe('Server', () => {
           expect.assertions(2)
           try {
             await client.query({
-              query: gql`query validButNotWhitelisted {
+              query: gql`query validButDisallowed {
                   testTwo
               }`
             })


### PR DESCRIPTION

# Context
The config option WHITELIST_PATH was deprecated, but with the major version bump, it can be removed.

# Proposed Solution
Remove support for WHITELIST_PATH

# Important Changes Introduced
BREAKING CHANGE: WHITELIST_PATH is now ALLOW_LIST_PATH

