### PR TITLE
hasura-cli-ext: bump sha256 to current version

### DIFF
--- a/nix/hasura-cli-ext/impure.nix
+++ b/nix/hasura-cli-ext/impure.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.3.2";
   src = fetchurl {
     url = "https://github.com/hasura/graphql-engine/releases/download/v${version}/cli-ext-hasura-linux.tar.gz";
-    sha256 = "013m4f56mf2rx6mjkfki64xblvjjcwb0n70ny8wykwqzj5cp1pr5";
+    sha256 = "1hibvwiknbbwc6ir1wx044rk67myxcd16plgl6azyhyifasbx9zq";
   };
   sourceRoot = ".";
   buildPhase = ":";


### PR DESCRIPTION
Updating the hasura-cli-ext tarball has after it has been bumped to the latest version.
