### PR TITLE
Fix/reward stakereregistration order by

### DIFF
--- a/config/network/allegra/cardano-node/config.json
+++ b/config/network/allegra/cardano-node/config.json
@@ -74,6 +74,9 @@
       ],
       "cardano.node.metrics": [
         "EKGViewBK"
+      ],
+      "cardano.node.resources": [
+        "EKGViewBK"
       ]
     },
     "mapSubtrace": {

--- a/config/network/launchpad/cardano-node/config.json
+++ b/config/network/launchpad/cardano-node/config.json
@@ -73,6 +73,9 @@
       ],
       "cardano.node.metrics": [
         "EKGViewBK"
+      ],
+      "cardano.node.resources": [
+        "EKGViewBK"
       ]
     },
     "mapSubtrace": {

--- a/config/network/mainnet/cardano-node/config.json
+++ b/config/network/mainnet/cardano-node/config.json
@@ -88,6 +88,9 @@
           "kind": "UserDefinedBK",
           "name": "LiveViewBackend"
         }
+      ],
+      "cardano.node.resources": [
+        "EKGViewBK"
       ]
     },
     "mapSubtrace": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         max-size: "200k"
         max-file: "10"
   cardano-node:
-    image: rhyslbw/cardano-node:${CARDANO_NODE_VERSION:-c6c5758aa5991a1c0d821622349f39c12a40e1ad}
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.24.2}
     command: [
       "run",
       "--config", "/config/config.json",

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -363,8 +363,8 @@ input Reward_bool_exp {
 }
 
 input Reward_order_by {
-  address: StakeAddress_comparison_exp
-  amount: text_comparison_exp
+  address: order_by
+  amount: order_by
   earnedIn: Epoch_order_by
   stakePool: StakePool_order_by
 }
@@ -433,7 +433,7 @@ type StakeDeregistration_aggregate_fields {
 }
 
 input StakeDeregistration_order_by {
-  address: StakeAddress_comparison_exp
+  address: order_by
   transaction: Transaction_order_by
 }
 


### PR DESCRIPTION
# Context
Closes #382, and bumps to the released version of `cardano-node@1.24.2`

