### PR TITLE
fix: casing on invalid hereafter in GraphQL schema

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -625,7 +625,7 @@ type Transaction {
     where: TransactionInput_bool_exp
   ): TransactionInput_aggregate!
   invalidBefore: String
-  invalidHereAfter: String
+  invalidHereafter: String
   metadata: [TransactionMetadata]
   outputs (
     limit: Int
@@ -659,7 +659,7 @@ input Transaction_order_by {
   hash: order_by
   includedAt: order_by
   invalidBefore: order_by_with_nulls
-  invalidHereAfter: order_by_with_nulls
+  invalidHereafter: order_by_with_nulls
   size: order_by
   totalOutput: order_by
   withdrawals: order_by
@@ -677,7 +677,7 @@ input Transaction_bool_exp {
   includedAt: Date_comparison_exp
   inputs: TransactionInput_bool_exp
   invalidBefore: text_comparison_exp
-  invalidHereAfter: text_comparison_exp
+  invalidHereafter: text_comparison_exp
   metadata: TransactionMetadata_bool_exp
   outputs: TransactionOutput_bool_exp
   size: BigInt_comparison_exp
@@ -709,7 +709,7 @@ type Transaction_max_fields {
   deposit: String
   fee: String
   invalidBefore: String
-  invalidHereAfter: String
+  invalidHereafter: String
   size: String
   totalOutput: String
   withdrawals: Withdrawal_max_fields
@@ -719,7 +719,7 @@ type Transaction_min_fields {
   deposit: String
   fee: String
   invalidBefore: String
-  invalidHereAfter: String
+  invalidHereafter: String
   size: String
   totalOutput: String
   withdrawals: Withdrawal_min_fields


### PR DESCRIPTION
# Context
Closes #390

# Proposed Solution
Correct casing

# Test results
```
Test Suites: 13 passed, 13 total
Tests:       42 passed, 42 total
Snapshots:   16 passed, 16 total
Time:        52.647 s
Ran all test suites matching /query/i.
Done in 54.78s.

> @cardano-graphql/cli
yarn run v1.22.5
$ NODE_ENV=test jest -c ./test/jest.config.js cli.test.ts --ci
 PASS  test/cli.test.ts (14.943 s)
  CLI Test
    ✓ Shows the program help if no arguments are passed (245 ms)
    system-info command
      ✓ Logs an object useful during issue reporting (254 ms)
    docker command
      ✓ Shows the program help if no arguments are passed (480 ms)
      init
        ✓ writes a config file to the appropriate platform-specific path, scoped by command, copies a docker compose file to use as boilerplate, and handles secret generation (556 ms)
        ✓ can be used in automated processes using command arguments (548 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   3 passed, 3 total
Time:        15.394 s
Ran all test suites matching /cli.test.ts/i.
Done in 16.21s.

 PASS  test/Server.test.ts (12.239 s)
  Server
    ✓ can be configured to listen on a specified host and port (53 ms)
    Server - Internals
      Allowing specific queries
        Booting the server without providing an allow-list
          ✓ returns data for all valid queries (15 ms)
        Providing an allow-list produced by persistgraphql, intended to limit the API for specific application requirements
          ✓ Accepts allowed queries (11 ms)
          ✓ Returns a forbidden error and 403 HTTP response error if a valid but disallowed operation is sent (10 ms)
      configuring introspection
        ✓ stops the schema being introspected (37 ms)
        ✓ allows the schema to be introspected (20 ms)
        ✓ cannot be used with the allow-list feature enabled (1 ms)
      configuring metrics
        ✓ requires tracing to be enabled (5 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        12.548 s
Ran all test suites.


