### PR TITLE
fix: Replaces the time-based logic to determine sync progress and initialisation state

### DIFF
--- a/packages/api-cardano-db-hasura/package.json
+++ b/packages/api-cardano-db-hasura/package.json
@@ -43,7 +43,6 @@
     "apollo-server": "^2.15.1",
     "bignumber.js": "^9.0.1",
     "cross-fetch": "^3.0.4",
-    "dayjs": "^1.8.29",
     "graphql": "14.5.8",
     "graphql-bigint": "^1.0.0",
     "graphql-scalars": "^1.2.1",

--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -23,7 +23,7 @@ export class CardanoNodeClient {
   constructor (
     private cardanoCli: CardanoCli,
     pollingInterval: number,
-    private currentEraFirstSlot: number,
+    readonly currentEraFirstSlot: number,
     private logger: Logger = dummyLogger
   ) {
     this.currentEraFirstSlot = currentEraFirstSlot
@@ -35,10 +35,16 @@ export class CardanoNodeClient {
     )
   }
 
+  public async getTip () {
+    const tip = this.cardanoCli.getTip()
+    this.logger.debug('getTip', { module: 'CardanoNodeClient', value: tip })
+    return tip
+  }
+
   public async initialize () {
     await pRetry(async () => {
       await fs.stat(process.env.CARDANO_NODE_SOCKET_PATH)
-      const { slotNo } = await this.cardanoCli.getTip()
+      const { slotNo } = await this.getTip()
       if (slotNo < this.currentEraFirstSlot) {
         this.logger.debug('cardano-node tip', { module: 'CardanoNodeClient', value: slotNo })
         this.logger.debug('currentEraFirstSlot', { module: 'CardanoNodeClient', value: this.currentEraFirstSlot })

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -126,7 +126,8 @@ export async function buildSchema (
         },
         cardanoDbMeta: async () => {
           try {
-            return hasuraClient.getMeta()
+            const tip = await cardanoNodeClient.getTip()
+            return hasuraClient.getMeta(tip.blockNo)
           } catch (error) {
             throw new ApolloError(error)
           }


### PR DESCRIPTION
# Context
Fixes #248

# Proposed Solution
Enabled by having direct access to `cardano-node` via `cardano-cli`, the node tip is used as the base value to determine the sync progress of `cardano-db-sync`. In addition, the initialisation state is now determined by asserting the most recent epoch in the table matches the tip's `epochNo`

