### PR TITLE
Refactor/align logger env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     environment:
       - ALLOW_INTROSPECTION=true
       - CACHE_ENABLED=true
-      - LOGGER_LEVEL=${LOGGER_LEVEL:-info}
+      - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}
     expose:
       - ${API_PORT:-3100}
     ports:

--- a/nix/nixos/cardano-graphql-service.nix
+++ b/nix/nixos/cardano-graphql-service.nix
@@ -53,7 +53,7 @@ in {
         default = "allegra";
       };
       
-      logLevel = lib.mkOption {
+      loggerMinSeverity = lib.mkOption {
         type = lib.types.str;
         default = "info";
       };
@@ -156,7 +156,7 @@ in {
         HASURA_GRAPHQL_ENABLE_TELEMETRY = false;
         HASURA_URI = hasuraBaseUri;
         JQ_PATH = pkgs.jq + "/bin/jq";
-        LOGGER_LEVEL = cfg.logLevel;
+        LOGGER_MIN_SEVERITY = cfg.loggerMinSeverity;
         POSTGRES_DB = cfg.db;
         POSTGRES_HOST = cfg.dbHost;
         POSTGRES_PASSWORD = cfg.dbPassword;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -5,7 +5,7 @@ import { Config as ServerConfig } from './Server'
 import { LogLevelString } from 'bunyan'
 
 export type Config = ServerConfig & ApiCardanoDbHasuraConfig & {
-  loggerLevel: LogLevelString
+  loggerMinSeverity: LogLevelString
 }
 
 export async function getConfig (): Promise<Config> {
@@ -63,7 +63,7 @@ export async function getConfig (): Promise<Config> {
     currentEraFirstSlot: env.currentEraFirstSlot || 16588800,
     db,
     eraName: env.eraName || 'allegra',
-    loggerLevel: env.loggerLevel || 'info' as LogLevelString,
+    loggerMinSeverity: env.loggerMinSeverity || 'info' as LogLevelString,
     jqPath: env.jqPath || 'jq',
     listenAddress: env.listenAddress || '0.0.0.0',
     pollingIntervalAdaSupply: env.pollingIntervalAdaSupply || 1000 * 60,
@@ -88,7 +88,7 @@ function filterAndTypecastEnvs (env: any) {
     HASURA_URI,
     JQ_PATH,
     LISTEN_ADDRESS,
-    LOGGER_LEVEL,
+    LOGGER_MIN_SEVERITY,
     POLLING_INTERVAL_ADA_SUPPLY,
     POSTGRES_DB,
     POSTGRES_DB_FILE,
@@ -120,7 +120,7 @@ function filterAndTypecastEnvs (env: any) {
     hasuraUri: HASURA_URI,
     jqPath: JQ_PATH,
     listenAddress: LISTEN_ADDRESS,
-    loggerLevel: LOGGER_LEVEL as LogLevelString,
+    loggerMinSeverity: LOGGER_MIN_SEVERITY as LogLevelString,
     pollingIntervalAdaSupply: Number(POLLING_INTERVAL_ADA_SUPPLY),
     postgresDb: POSTGRES_DB,
     postgresDbFile: POSTGRES_DB_FILE,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,7 @@ export * from './config'
   const config = await getConfig()
   const logger: Logger = createLogger({
     name: 'cardano-graphql',
-    level: config.loggerLevel
+    level: config.loggerMinSeverity
   })
   try {
     const server = await CompleteApiServer(config, logger)

--- a/scripts/dev_init.sh
+++ b/scripts/dev_init.sh
@@ -20,4 +20,5 @@ cabal install cardano-cli \
   --overwrite-policy=always \
   -f -systemd
 curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | INSTALL_PATH=${BIN_DIR} bash
+HASURA_GRAPHQL_ENABLE_TELEMETRY=false
 ${BIN_DIR}/hasura --skip-update-check update-cli --version v1.3.3


### PR DESCRIPTION
# Context
The logger ENV is different to `cardano-rosetta` , and it would be best to standardise here.

# Proposed Solution
Rename the ENV

# Important Changes Introduced
Also disables the last remaining Hasura telemetry occurrence 
