### PR TITLE
refactor: remove static era definition

### DIFF
--- a/packages/api-cardano-db-hasura/src/CardanoCli.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoCli.ts
@@ -2,6 +2,7 @@ import { exec } from 'child_process'
 import { Genesis } from './graphql_types'
 import { Config } from './Config'
 import { LedgerState } from './CardanoNodeClient'
+import { knownEras } from '@cardano-graphql/util'
 
 export interface CardanoCliTip {
   blockNo: number,
@@ -15,28 +16,35 @@ export interface CardanoCli {
 
 export function createCardanoCli (
   cardanoCliPath: Config['cardanoCliPath'],
-  eraName: Config['eraName'],
   genesis: Genesis['shelley'],
   jqPath: Config['jqPath']
 ): CardanoCli {
   const networkArg = genesis.networkId === '1'
     ? '--mainnet'
     : `--testnet-magic ${genesis.networkMagic.toString()}`
-  const eraArg = `--${eraName}-era`
   return {
     getLedgerState: () => {
       return new Promise((resolve, reject) => {
-        exec(
-          `${cardanoCliPath} query ledger-state ${networkArg} ${eraArg} | 
+        for (const era of knownEras) {
+          exec(
+            `${cardanoCliPath} query ledger-state ${networkArg} --${era}-era | 
           ${jqPath} "{accountState: .nesEs.esAccountState, esNonMyopic: { rewardPot: .nesEs.esNonMyopic.rewardPotNM } }"
           `,
-          (error, stdout, stderr) => {
-            if (error !== null || stderr.toString() !== '') {
-              return reject(new Error(stderr.toString()))
+            (error, stdout, stderr) => {
+              if (error !== null || stderr.toString() !== '') {
+                if (
+                  stderr.toString().match(/EraMismatch/g) !== null ||
+                  stderr.toString().match(/The attempted local state query does not support the/g) !== null
+                ) {
+                } else {
+                  reject(new Error(stderr.toString()))
+                }
+              } else {
+                resolve(JSON.parse(stdout))
+              }
             }
-            return resolve(JSON.parse(stdout))
-          }
-        )
+          )
+        }
       })
     },
     getTip: () => {

--- a/packages/api-cardano-db-hasura/src/Config.ts
+++ b/packages/api-cardano-db-hasura/src/Config.ts
@@ -11,7 +11,6 @@ export interface Config {
     port: number
     user: string,
   },
-  eraName: string,
   genesis: {
     byronPath: string,
     shelleyPath: string

--- a/packages/server/src/CompleteApiServer.ts
+++ b/packages/server/src/CompleteApiServer.ts
@@ -28,7 +28,7 @@ export async function CompleteApiServer (
   }
   if (config.cardanoCliPath !== undefined) {
     cardanoNodeClient = new CardanoNodeClient(
-      createCardanoCli(config.cardanoCliPath, config.eraName, genesis.shelley, config.jqPath),
+      createCardanoCli(config.cardanoCliPath, genesis.shelley, config.jqPath),
       1000 * 60 * 10,
       config.currentEraFirstSlot,
       logger

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -62,7 +62,6 @@ export async function getConfig (): Promise<Config> {
     // defaults to mainnet
     currentEraFirstSlot: env.currentEraFirstSlot || 16588800,
     db,
-    eraName: env.eraName || 'allegra',
     loggerMinSeverity: env.loggerMinSeverity || 'info' as LogLevelString,
     jqPath: env.jqPath || 'jq',
     listenAddress: env.listenAddress || '0.0.0.0',
@@ -81,7 +80,6 @@ function filterAndTypecastEnvs (env: any) {
     CARDANO_CLI_PATH,
     CARDANO_NODE_SOCKET_PATH,
     CURRENT_ERA_FIRST_SLOT,
-    ERA_NAME,
     GENESIS_FILE_BYRON,
     GENESIS_FILE_SHELLEY,
     HASURA_CLI_PATH,
@@ -111,7 +109,6 @@ function filterAndTypecastEnvs (env: any) {
     cardanoCliPath: CARDANO_CLI_PATH,
     cardanoNodeSocketPath: CARDANO_NODE_SOCKET_PATH,
     currentEraFirstSlot: Number(CURRENT_ERA_FIRST_SLOT),
-    eraName: ERA_NAME,
     genesis: {
       byronPath: GENESIS_FILE_BYRON,
       shelleyPath: GENESIS_FILE_SHELLEY

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -2,6 +2,7 @@ import { onFailedAttemptFor } from './onFailedAttemptFor'
 import { loadQueryNode } from './queryNodeLoading'
 import * as scalars from './scalars'
 export * from './data_fetching'
+export * from './knownEras'
 
 export default {
   onFailedAttemptFor,

--- a/packages/util/src/knownEras.ts
+++ b/packages/util/src/knownEras.ts
@@ -1,0 +1,1 @@
+export const knownEras = ['mary', 'allegra', 'shelley', 'byron']

--- a/scripts/export_env.sh
+++ b/scripts/export_env.sh
@@ -12,14 +12,12 @@ case "$NETWORK" in
         mainnet)
             API_PORT=3100
             CURRENT_ERA_FIRST_SLOT=16588800
-            ERA_NAME=allegra
             HASURA_PORT=8090
             POSTGRES_PORT=5442
             ;;
         testnet)
             API_PORT=3101
             CURRENT_ERA_FIRST_SLOT=13694400
-            ERA_NAME=allegra
             HASURA_PORT=8091
             POSTGRES_PORT=5443
             ;;


### PR DESCRIPTION
# Context

to successfully cross an epoch boundary, the era needs to be determined dynamically
this change removes the static configuration.

# Proposed Solution
Loop through eras, starting with the next protocol that will be transitioned to 

# Important Changes Introduced
No longer set the ENV
