### PR TITLE
Chore/rename acronym to ticker

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -50,7 +50,7 @@
     permission:
       check: {}
       columns:
-      - acronym
+      - ticker
       - assetId
       - assetName
       - description
@@ -66,7 +66,7 @@
   - role: cardano-graphql
     permission:
       columns:
-      - acronym
+      - ticker
       - assetId
       - assetName
       - description
@@ -84,7 +84,7 @@
   - role: cardano-graphql
     permission:
       columns:
-      - acronym
+      - ticker
       - assetId
       - assetName
       - description

--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -801,9 +801,6 @@
       allow_aggregations: true
 - table:
     schema: public
-    name: block
-- table:
-    schema: public
     name: pool_owner
   object_relationships:
   - name: stakePool

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS "Asset"
   AS
   SELECT
     DISTINCT CONCAT(RIGHT(CONCAT(E'\\', policy), -3), RIGHT(CONCAT(E'\\', name), -3)) as "assetId",
-    CAST(NULL AS TEXT) AS "acronym",
+    CAST(NULL AS TEXT) AS "ticker",
     name as "assetName",
     CAST(NULL AS TEXT) AS "description",
     CAST(NULL AS TEXT) AS "logo",

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -244,7 +244,7 @@ type Ada {
 }
 
 type Asset {
-  acronym: String
+  ticker: String
   assetId: String!
   assetName: String
   description: String
@@ -260,7 +260,7 @@ input Asset_bool_exp {
   _and: [Asset_bool_exp]
   _not: Asset_bool_exp
   _or: [Asset_bool_exp]
-  acronym: text_comparison_exp
+  ticker: text_comparison_exp
   assetId: text_comparison_exp
   assetName: text_comparison_exp
   description: text_comparison_exp

--- a/packages/api-cardano-db-hasura/src/DataSyncController.ts
+++ b/packages/api-cardano-db-hasura/src/DataSyncController.ts
@@ -12,7 +12,7 @@ export interface Signature {
 }
 
 export interface AssetMetadata {
-  acronym: {
+  ticker: {
     value: string
     anSignatures: Signature[]
   }
@@ -153,7 +153,7 @@ export class DataSyncController {
       const response = await this.axiosClient.post('query', {
         subjects: assets.map(asset => asset.assetId),
         properties: [
-          'acronym',
+          'ticker',
           'description',
           'logo',
           'name',

--- a/packages/api-cardano-db-hasura/src/HasuraClient.ts
+++ b/packages/api-cardano-db-hasura/src/HasuraClient.ts
@@ -357,7 +357,7 @@ export class HasuraClient {
     this.logger.info('adding metadata to asset', { module: 'HasuraClient', value: { assetId: metadata.subject, metadataHash } })
     return this.client.mutate({
       mutation: gql`mutation AddAssetMetadata(
-          $acronym: String
+          $ticker: String
           $assetId: String!
           $description: String
           $logo: String
@@ -371,7 +371,7 @@ export class HasuraClient {
                   assetId: { _eq: $assetId }
               },
               _set: {
-                  acronym: $acronym,
+                  ticker: $ticker,
                   description: $description,
                   logo: $logo,
                   metadataHash: $metadataHash,
@@ -388,7 +388,7 @@ export class HasuraClient {
           }
       }`,
       variables: {
-        acronym: metadata.acronym?.value,
+        ticker: metadata.ticker?.value,
         assetId: metadata.subject,
         description: metadata.description?.value,
         logo: metadata.logo?.value,

--- a/packages/api-cardano-db-hasura/src/example_queries/assets/assets.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/assets/assets.graphql
@@ -1,6 +1,6 @@
 query assets {
     assets {
-        acronym
+        ticker
         assetId
         assetName
         description


### PR DESCRIPTION
# Context

The list of well-known asset metadata properties used the term `acronym`, which has since been changed for accuracy of the intent.

# Proposed Solution
Simply rename to `ticker`

# Important Changes Introduced

