### PR TITLE
chore: Correct Transaction.metadata type

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -10,6 +10,7 @@ scalar Hash28Hex
 scalar Hash32Hex
 scalar IPv4
 scalar IPv6
+scalar JSON
 scalar JSONObject
 scalar Percentage
 scalar StakeAddress
@@ -1009,7 +1010,7 @@ type TransactionInput_sum_fields {
 
 type TransactionMetadata {
   key: String!
-  value: JSONObject!
+  value: JSON!
 }
 
 input TransactionMetadata_bool_exp {

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -10,6 +10,7 @@ import {
   IPv4Resolver,
   IPv6Resolver,
   JSONResolver,
+  JSONObjectResolver,
   TimestampResolver,
   URLResolver
 } from 'graphql-scalars'
@@ -25,7 +26,8 @@ export const scalarResolvers = {
   Hash32Hex: util.scalars.Hash32Hex,
   IPv4: IPv4Resolver,
   IPv6: IPv6Resolver,
-  JSONObject: JSONResolver,
+  JSON: JSONResolver,
+  JSONObject: JSONObjectResolver,
   Percentage: util.scalars.Percentage,
   StakeAddress: util.scalars.StakeAddress,
   StakePoolID: util.scalars.StakePoolID,


### PR DESCRIPTION
# Context
Despite the name, `JSONObject` was currently mapped to the underlying JSON resolver
as a workaround to avoid breaking changes.

# Proposed Solution
BREAKING CHANGE: Transaction.metadata is now JSON type, not JSONObject

# Important Changes Introduced

