### PR TITLE
Chore/ Improve ada supply result, temporarily disable total supply to reduce resource demand

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -297,7 +297,7 @@ type AssetBalance {
 type AssetSupply {
   circulating: String!
   max: String!
-  total: String!
+  total: String
 }
 
 input AssetSupply_bool_exp {

--- a/packages/api-cardano-db-hasura/src/CardanoCli.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoCli.ts
@@ -1,7 +1,6 @@
 import { exec } from 'child_process'
 import { Genesis, ShelleyProtocolParams } from './graphql_types'
 import { Config } from './Config'
-import { LedgerState } from './CardanoNodeClient'
 import { knownEras, capitalizeFirstChar } from '@cardano-graphql/util'
 
 export interface CardanoCliTip {
@@ -19,7 +18,6 @@ const isEraMismatch = (errorMessage: string, era: string): boolean => {
 }
 
 export interface CardanoCli {
-  getLedgerState(): Promise<LedgerState>,
   getProtocolParams(): Promise<ProtocolParams>,
   getTip(): Promise<CardanoCliTip>,
   submitTransaction(filePath: string): Promise<void>
@@ -63,13 +61,6 @@ export function createCardanoCli (
     })
   }
   return {
-    getLedgerState: () => query<LedgerState>(
-      'ledger-state',
-      {
-        jqOperation: '"{accountState: .nesEs.esAccountState, esNonMyopic: { rewardPot: .nesEs.esNonMyopic.rewardPotNM } }"',
-        withEraFlag: true
-      }
-    ),
     getProtocolParams: () => query<ProtocolParams>(
       'protocol-parameters',
       {

--- a/packages/api-cardano-db-hasura/src/example_queries/assets/assets.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/assets/assets.graphql
@@ -4,6 +4,7 @@ query assets {
         assetId
         assetName
         description
+        fingerprint
         logo
         name
         unit

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -14,7 +14,6 @@ import {
   TimestampResolver,
   URLResolver
 } from 'graphql-scalars'
-import BigNumber from 'bignumber.js'
 import { CardanoNodeClient } from './CardanoNodeClient'
 const GraphQLBigInt = require('graphql-bigint')
 
@@ -39,7 +38,7 @@ export const scalarResolvers = {
 export async function buildSchema (
   hasuraClient: HasuraClient,
   genesis: Genesis,
-  cardanoNodeClient?: CardanoNodeClient
+  cardanoNodeClient: CardanoNodeClient
 ) {
   const throwIfNotInCurrentEra = async (queryName: string) => {
     if (!(await cardanoNodeClient.isInCurrentEra())) {
@@ -90,10 +89,7 @@ export async function buildSchema (
           return {
             supply: {
               circulating: hasuraClient.adaCirculatingSupplyFetcher.value,
-              max: genesis.shelley.maxLovelaceSupply,
-              total: new BigNumber(genesis.shelley.maxLovelaceSupply)
-                .minus(new BigNumber(cardanoNodeClient.ledgerStateFetcher.value.accountState._reserves))
-                .toString()
+              max: genesis.shelley.maxLovelaceSupply
             }
           }
         },

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -86,9 +86,13 @@ export async function buildSchema (
         },
         ada: async () => {
           await throwIfNotInCurrentEra('ada')
+          const circulating = hasuraClient.adaCirculatingSupplyFetcher.value
+          if (circulating === undefined) {
+            return new ApolloError('ada query results are not ready yet. This can occur during startup.')
+          }
           return {
             supply: {
-              circulating: hasuraClient.adaCirculatingSupplyFetcher.value,
+              circulating,
               max: genesis.shelley.maxLovelaceSupply
             }
           }

--- a/packages/api-cardano-db-hasura/test/__snapshots__/assets.query.test.ts.snap
+++ b/packages/api-cardano-db-hasura/test/__snapshots__/assets.query.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`assets can return information on assets 1`] = `Array []`;

--- a/packages/api-cardano-db-hasura/test/ada.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/ada.query.test.ts
@@ -29,10 +29,8 @@ describe('ada', () => {
     const { ada } = result.data
     const circulatingSupply = new BigNumber(ada.supply.circulating).toNumber()
     const maxSupply = new BigNumber(ada.supply.max).toNumber()
-    const totalSupply = new BigNumber(ada.supply.total).toNumber()
     expect(maxSupply).toEqual(genesis.shelley.maxLovelaceSupply)
     expect(maxSupply).toBeGreaterThanOrEqual(circulatingSupply)
-    expect(maxSupply).toBeGreaterThanOrEqual(totalSupply)
-    expect(totalSupply).toBeGreaterThan(circulatingSupply)
+    expect(ada.supply.total).toBeNull()
   })
 })

--- a/packages/api-cardano-db-hasura/test/assets.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/assets.query.test.ts
@@ -29,6 +29,7 @@ describe('assets', () => {
     const { assets_aggregate, assets } = result.data
     const { aggregate } = assets_aggregate
     expect(aggregate.count).toBeDefined()
-    expect(assets).toMatchSnapshot()
+    expect(assets.length).toBeGreaterThan(0)
+    expect(assets[0].fingerprint.slice(0, 5)).toBe('asset')
   })
 })

--- a/packages/api-cardano-db-hasura/test/stakePool.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/stakePool.query.test.ts
@@ -90,6 +90,6 @@ describe('stakePools', () => {
     })
     const { stakePools_aggregate } = result.data
     expect(parseInt(stakePools_aggregate.aggregate.count)).toBeGreaterThan(0)
-    expect(parseInt(stakePools_aggregate.aggregate.count)).toBeLessThan(600)
+    expect(parseInt(stakePools_aggregate.aggregate.count)).toBeLessThan(800)
   })
 })

--- a/packages/server/src/CompleteApiServer.ts
+++ b/packages/server/src/CompleteApiServer.ts
@@ -30,7 +30,6 @@ export async function CompleteApiServer (
   if (config.cardanoCliPath !== undefined) {
     cardanoNodeClient = new CardanoNodeClient(
       createCardanoCli(config.cardanoCliPath, genesis.shelley, config.jqPath),
-      1000 * 60 * 10,
       genesis.shelley.protocolParams.protocolVersion.major,
       logger
     )


### PR DESCRIPTION
# Context
The benefit of the `cardano-cli` ledger state query is overshadowed by the resource demand. It's not a
supported interface, so was also always a risk for continual breaking changes.The total ada supply will be restored if the information can be accessed via an official API.

- Closes #435 
- Closes #440 

# Proposed Solution
- Stop using the `cardano-cli` ledger-state query to access the reserves balance.
- Include rewards in the circulating supply calculation 

# Important Changes Introduced
BREAKING CHANGE: AssetSupply.total is now an optional field, and will return null
