### PR TITLE
fix: disable CORS in Hasura graphql-engine

### DIFF
--- a/nix/nixos/graphql-engine-service.nix
+++ b/nix/nixos/graphql-engine-service.nix
@@ -79,7 +79,8 @@ in {
           --port ${toString cfg.dbPort} \
           serve \
           --server-port ${toString cfg.enginePort} \
-          --enable-telemetry=false
+          --enable-telemetry=false \
+          --disable-cors
       '';
     };
   };

--- a/packages/api-cardano-db-hasura/hasura/docker-entrypoint.sh
+++ b/packages/api-cardano-db-hasura/hasura/docker-entrypoint.sh
@@ -8,4 +8,7 @@ POSTGRES_USER=${POSTGRES_USER:-$(cat ${SECRET_DIR}/postgres_user)}
 POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-$(cat ${SECRET_DIR}/postgres_password)}
 HASURA_GRAPHQL_DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
-exec graphql-engine --database-url $HASURA_GRAPHQL_DATABASE_URL serve
+exec graphql-engine \
+  --disable-cors \
+  --database-url $HASURA_GRAPHQL_DATABASE_URL \
+  serve


### PR DESCRIPTION
# Context
Hasura is considered a private service in this stack. CORS is configured with
either the `cardano-graphql` server, or a reverse proxy if the former is not public.

Closes #392

# Proposed Solution
Disable CORS when starting the Hasura `graphql-engine`. Use https://github.com/input-output-hk/cardano-graphql/wiki/Configuration#allowed_origins-string--regexp--string--regexp

# Important Changes Introduced

