### PR TITLE
chore: remove Asset.unit

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -60,7 +60,6 @@
       - metadataHash
       - name
       - policyId
-      - unit
       - url
       backend_only: false
   select_permissions:
@@ -77,7 +76,6 @@
       - metadataHash
       - name
       - policyId
-      - unit
       - url
       filter: {}
       limit: 2500
@@ -96,7 +94,6 @@
       - metadataHash
       - name
       - policyId
-      - unit
       - url
       filter: {}
       check: {}

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -12,7 +12,6 @@ CREATE TABLE IF NOT EXISTS "Asset"
     CAST(NULL AS CHAR(40)) AS "metadataHash",
     CAST(NULL AS TEXT) AS "name",
     policy as "policyId",
-    CAST(NULL AS JSONB) AS "unit",
     CAST(NULL AS TEXT) AS "url"
   FROM ma_tx_out;
 

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -253,7 +253,6 @@ type Asset {
   logo: String
   metadataHash: String
   name: String
-  unit: JSONObject
   url: String
   policyId: Hash28Hex!
 }
@@ -270,7 +269,6 @@ input Asset_bool_exp {
   logo: text_comparison_exp
   name: text_comparison_exp
   policyId: text_comparison_exp
-  unit: JSONObject
   url: text_comparison_exp
 }
 

--- a/packages/api-cardano-db-hasura/src/DataSyncController.ts
+++ b/packages/api-cardano-db-hasura/src/DataSyncController.ts
@@ -42,13 +42,6 @@ export interface AssetMetadata {
     hashFn: string
   }
   subject: string
-  unit: {
-    value: {
-      decimals: number
-      name: string
-    }
-    anSignatures: Signature[]
-  }
   url: {
     value: string
     anSignatures: Signature[]
@@ -166,7 +159,6 @@ export class DataSyncController {
           'logo',
           'name',
           'ticker',
-          'unit',
           'url'
         ]
       })

--- a/packages/api-cardano-db-hasura/src/HasuraClient.ts
+++ b/packages/api-cardano-db-hasura/src/HasuraClient.ts
@@ -438,7 +438,6 @@ export class HasuraClient {
           $logo: String
           $metadataHash: bpchar!
           $name: String
-          $unit: jsonb
           $url: String
       ) {
           update_assets(
@@ -451,7 +450,6 @@ export class HasuraClient {
                   logo: $logo,
                   metadataHash: $metadataHash,
                   name: $name,
-                  unit: $unit
                   url: $url
               }
           ) {
@@ -469,7 +467,6 @@ export class HasuraClient {
         logo: metadata.logo?.value,
         metadataHash,
         name: metadata.name?.value,
-        unit: metadata.unit ? JSON.stringify(metadata.unit.value) : undefined,
         url: metadata.url?.value
       }
     })

--- a/packages/api-cardano-db-hasura/src/example_queries/assets/assets.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/assets/assets.graphql
@@ -1,5 +1,7 @@
-query assets {
-    assets {
+query assets (
+    $where: Asset_bool_exp
+) {
+    assets (where: $where) {
         ticker
         assetId
         assetName
@@ -7,7 +9,6 @@ query assets {
         fingerprint
         logo
         name
-        unit
         url
         policyId
     }

--- a/packages/api-cardano-db-hasura/test/assets.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/assets.query.test.ts
@@ -32,4 +32,23 @@ describe('assets', () => {
     expect(assets.length).toBeGreaterThan(0)
     expect(assets[0].fingerprint.slice(0, 5)).toBe('asset')
   })
+
+  it('can return information on assets by fingerprint', async () => {
+    const result = await client.query({
+      query: await loadQueryNode('assets'),
+      variables: {
+        where: { fingerprint: { _eq: 'asset12h3p5l3nd5y26lr22am7y7ga3vxghkhf57zkhd' } }
+      }
+    })
+    const { assets } = result.data
+    expect(assets[0].assetId).toBeDefined()
+    expect(assets[0].assetName).toBeDefined()
+    expect(assets[0].description).toBeDefined()
+    expect(assets[0].fingerprint).toBeDefined()
+    expect(assets[0].logo).toBeDefined()
+    expect(assets[0].name).toBeDefined()
+    expect(assets[0].policyId).toBeDefined()
+    expect(assets[0].ticker).toBeDefined()
+    expect(assets[0].url).toBeDefined()
+  })
 })


### PR DESCRIPTION
# Context
A decision  was made to remove this property from asset metadata,
to revisit supporting the intent at a later stage.

# Proposed Solution
- Remove the Asset.unit property, table column, and reference to it in the metadata server request.
- Improves the test to confirm the return response.

```
 PASS  test/ada.query.test.ts
 PASS  test/cardano.query.test.ts
 PASS  test/stakeDeregistrations.query.test.ts
 PASS  test/stakeRegistrations.query.test.ts
 PASS  test/withdrawals.query.test.ts
 PASS  test/assets.query.test.ts
 PASS  test/transactions.query.test.ts
 PASS  test/blocks.query.test.ts
 PASS  test/genesis.query.test.ts
 PASS  test/delegations.query.test.ts
 PASS  test/rewards.query.test.ts
 PASS  test/stakePool.query.test.ts (6.87 s)
 PASS  test/paymentAddress.query.test.ts (13.121 s)
 PASS  test/utxos.query.test.ts (14.849 s)
 PASS  test/epochs.query.test.ts (19.514 s)
 PASS  test/activeStake.query.test.ts (21.568 s)

Test Suites: 16 passed, 16 total
Tests:       48 passed, 48 total
Snapshots:   17 passed, 17 total
Time:        22.496 s, estimated 33 s
Ran all test suites matching /query/i.
Done in 24.61s.
```

