### PR TITLE
Fix/protocol major version feaures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,7 @@ COPY --from=haskell-builder /usr/local/bin/cardano-cli /usr/local/bin/
 COPY --from=downloader /usr/local/bin/hasura /usr/local/bin/hasura
 ENV \
   CARDANO_CLI_PATH=/usr/local/bin/cardano-cli \
+  CARDANO_NODE_CONFIG_PATH=/config/cardano-node/config.json \
   CARDANO_NODE_SOCKET_PATH=/node-ipc/node.socket \
   GENESIS_FILE_BYRON=/config/genesis/byron.json \
   GENESIS_FILE_SHELLEY=/config/genesis/shelley.json \
@@ -131,6 +132,7 @@ COPY --from=haskell-builder /usr/local/bin/cardano-cli /usr/local/bin/
 COPY --from=downloader /usr/local/bin/hasura /usr/local/bin/hasura
 ENV \
   CARDANO_CLI_PATH=/usr/local/bin/cardano-cli \
+  CARDANO_NODE_CONFIG_PATH=/config/cardano-node/config.json \
   CARDANO_NODE_SOCKET_PATH=/node-ipc/node.socket \
   GENESIS_FILE_BYRON=/config/genesis/byron.json \
   GENESIS_FILE_SHELLEY=/config/genesis/shelley.json \

--- a/nix/nixos/cardano-graphql-service.nix
+++ b/nix/nixos/cardano-graphql-service.nix
@@ -58,7 +58,11 @@ in {
         default = 3100;
       };
 
-      # Used if you tx submission is allowed
+      cardanoNodeConfigPath = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+      };
+      
       cardanoNodeSocketPath = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
@@ -152,6 +156,7 @@ in {
       requires = [ "graphql-engine.service" ];
       environment = lib.filterAttrs (k: v: v != null) {
         CARDANO_CLI_PATH = cfg.cardanoCliPackage + "/bin/cardano-cli";
+        CARDANO_NODE_CONFIG_PATH = cfg.cardanoNodeConfigPath;
         CARDANO_NODE_SOCKET_PATH = cfg.cardanoNodeSocketPath;
         GENESIS_FILE_BYRON = cfg.genesisByron;
         GENESIS_FILE_SHELLEY = cfg.genesisShelley;

--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -63,7 +63,7 @@ export class CardanoNodeClient {
     })
   }
 
-  public async isInCurrentEra () {
+  private async isInCurrentEra () {
     const { protocolVersion } = await this.getProtocolParams()
     this.logger.debug('Comparing current protocol params with last known major version from cardano-node config', {
       module: 'CardanoNodeClient',

--- a/packages/api-cardano-db-hasura/src/Config.ts
+++ b/packages/api-cardano-db-hasura/src/Config.ts
@@ -1,6 +1,7 @@
 
 export interface Config {
   cardanoCliPath: string,
+  cardanoNodeConfigPath: string,
   cardanoNodeSocketPath: string,
   db: {
     database: string,

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -39,7 +39,7 @@ export async function buildSchema (
   cardanoNodeClient: CardanoNodeClient
 ) {
   const throwIfNotInCurrentEra = async (queryName: string) => {
-    if (!(await cardanoNodeClient.isInCurrentEra())) {
+    if (!(await hasuraClient.isInCurrentEra())) {
       return new ApolloError(`${queryName} results are only available when close to the network tip. This is expected during the initial chain-sync.`)
     }
   }

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -40,7 +40,7 @@ export async function buildSchema (
 ) {
   const throwIfNotInCurrentEra = async (queryName: string) => {
     if (!(await hasuraClient.isInCurrentEra())) {
-      return new ApolloError(`${queryName} results are only available when close to the network tip. This is expected during the initial chain-sync.`)
+      throw new ApolloError(`${queryName} results are only available when close to the network tip. This is expected during the initial chain-sync.`)
     }
   }
   return makeExecutableSchema({

--- a/packages/server/src/CompleteApiServer.ts
+++ b/packages/server/src/CompleteApiServer.ts
@@ -28,10 +28,12 @@ export async function CompleteApiServer (
       ...config.genesis.shelleyPath !== undefined ? { shelley: require(config.genesis.shelleyPath) } : {}
     }
   }
+  const lastConfiguredMajorVersion = require(config.cardanoNodeConfigPath)['LastKnownBlockVersion-Major']
+
   if (config.cardanoCliPath !== undefined) {
     cardanoNodeClient = new CardanoNodeClient(
       createCardanoCli(config.cardanoCliPath, genesis.shelley, config.jqPath),
-      genesis.shelley.protocolParams.protocolVersion.major,
+      lastConfiguredMajorVersion,
       logger
     )
   }
@@ -39,6 +41,7 @@ export async function CompleteApiServer (
     config.hasuraCliPath,
     config.hasuraUri,
     config.pollingInterval.adaSupply,
+    lastConfiguredMajorVersion,
     logger
   )
   const db = new Db(config.db, logger)

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -14,6 +14,9 @@ export async function getConfig (): Promise<Config> {
   if (!env.cardanoNodeSocketPath) {
     throw new MissingConfig('CARDANO_NODE_SOCKET_PATH env not set')
   }
+  if (!env.cardanoNodeConfigPath) {
+    throw new MissingConfig('CARDANO_NODE_CONFIG_PATH env not set')
+  }
   if (!env.hasuraCliPath) {
     throw new MissingConfig('HASURA_CLI_PATH env not set')
   }
@@ -82,6 +85,7 @@ function filterAndTypecastEnvs (env: any) {
     API_PORT,
     CACHE_ENABLED,
     CARDANO_CLI_PATH,
+    CARDANO_NODE_CONFIG_PATH,
     CARDANO_NODE_SOCKET_PATH,
     GENESIS_FILE_BYRON,
     GENESIS_FILE_SHELLEY,
@@ -113,6 +117,7 @@ function filterAndTypecastEnvs (env: any) {
     apiPort: Number(API_PORT),
     cacheEnabled: CACHE_ENABLED === 'true',
     cardanoCliPath: CARDANO_CLI_PATH,
+    cardanoNodeConfigPath: CARDANO_NODE_CONFIG_PATH,
     cardanoNodeSocketPath: CARDANO_NODE_SOCKET_PATH,
     genesis: {
       byronPath: GENESIS_FILE_BYRON,

--- a/scripts/export_env.sh
+++ b/scripts/export_env.sh
@@ -35,6 +35,7 @@ esac
 export ALLOW_INTROSPECTION=true
 export API_PORT
 export CARDANO_CLI_PATH=${BIN_DIR}/cardano-cli
+export CARDANO_NODE_CONFIG_PATH=${CONFIG_DIR}/cardano-node/config.json
 export CARDANO_NODE_SOCKET_PATH=${STATE_DIR}/node-ipc/node.socket
 export GENESIS_FILE_BYRON=${CONFIG_DIR}/genesis/byron.json
 export GENESIS_FILE_SHELLEY=${CONFIG_DIR}/genesis/shelley.json


### PR DESCRIPTION
# Context

Fixes #435 
Fixes #435

# Proposed Solution
- Replace the genesis value with the value read from `cardano-node` config
- Add a `DataFetcher`  instance in `HasuraClient` to cache a DB query for the current protocol version, replacing the call to `CardanoNodeClient`, removing the use of `cardano-cli` from the request pipeline.

# Important Changes Introduced
- `CARDANO_NODE_CONFIG_PATH` is a new required config option 
