### PR TITLE
docker-compose: add a missing volume for cardano-graphql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ services:
         max-file: "10"
     volumes:
       - node-ipc:/node-ipc
+      - ./config/network/${NETWORK:-mainnet}:/config
 secrets:
   postgres_db:
     file: ./config/secrets/postgres_db


### PR DESCRIPTION
# Context

#455 introduced `CARDANO_NODE_CONFIG_PATH` with the default path to a config directory that should be mounted. The sample `docker-compose` file wasn't updated accordingly so #457 happened.

# Proposed Solution

This adds the missing `config` volume to `cardano-grapql` to the sample `docker-compose` file. Should correctly fix #457.

# Important Changes Introduced

