### PR TITLE
fix: assetFingerprint bug when no assetName present

### DIFF
--- a/packages/api-cardano-db-hasura/package.json
+++ b/packages/api-cardano-db-hasura/package.json
@@ -10,7 +10,7 @@
     "cleanup": "shx rm -rf dist node_modules src/graphql_types.ts",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "prepack": "yarn build",
-    "test": "yarn build && NODE_ENV=test jest -c ./test/jest.config.js query"
+    "test": "yarn build && NODE_ENV=test jest -c ./test/jest.config.js"
   },
   "repository": {
     "type": "git",

--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -1,22 +1,15 @@
-import AssetFingerprint from '@emurgo/cip14-js'
 import {
   ChainSyncClient,
   createChainSyncClient,
   isMaryBlock,
   Schema
 } from '@rhyslbw/ogmios-client'
+import { assetFingerprint } from './assetFingerprint'
 import { Config } from './Config'
 import { errors, RunnableModuleState } from '@cardano-graphql/util'
-import { Asset } from './graphql_types'
 import { HasuraClient } from './HasuraClient'
 import PgBoss from 'pg-boss'
 import { dummyLogger, Logger } from 'ts-log'
-
-export const assetFingerprint = (policyId: Asset['policyId'], assetName?: Asset['assetName']) =>
-  new AssetFingerprint(
-    Buffer.from(policyId, 'hex'),
-    assetName !== undefined ? Buffer.from(assetName, 'hex') : undefined)
-    .fingerprint()
 
 const MODULE_NAME = 'ChainFollower'
 

--- a/packages/api-cardano-db-hasura/src/assetFingerprint.ts
+++ b/packages/api-cardano-db-hasura/src/assetFingerprint.ts
@@ -1,0 +1,8 @@
+import { Asset } from './graphql_types'
+import AssetFingerprint from '@emurgo/cip14-js'
+
+export const assetFingerprint = (policyId: Asset['policyId'], assetName?: Asset['assetName']) =>
+  new AssetFingerprint(
+    Buffer.from(policyId, 'hex'),
+    Buffer.from(assetName ?? '', 'hex')
+  ).fingerprint()

--- a/packages/api-cardano-db-hasura/src/index.ts
+++ b/packages/api-cardano-db-hasura/src/index.ts
@@ -1,3 +1,4 @@
+export * from './assetFingerprint'
 export * from './AssetMetadata'
 export * from './CardanoNodeClient'
 export * from './ChainFollower'

--- a/packages/api-cardano-db-hasura/test/assetFingerprint.test.ts
+++ b/packages/api-cardano-db-hasura/test/assetFingerprint.test.ts
@@ -1,0 +1,46 @@
+import { assetFingerprint } from '@src/assetFingerprint'
+
+// https://github.com/cardano-foundation/CIPs/blob/master/CIP-0014/CIP-0014.md
+
+describe('assetFingerprint', () => {
+  it('produces a result to match the CIP test vectors', async () => {
+    expect(
+      assetFingerprint(
+        '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373')
+    ).toEqual('asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3')
+    expect(
+      assetFingerprint(
+        '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc37e')
+    ).toEqual('asset1nl0puwxmhas8fawxp8nx4e2q3wekg969n2auw3')
+    expect(
+      assetFingerprint(
+        '1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209')
+    ).toEqual('asset1uyuxku60yqe57nusqzjx38aan3f2wq6s93f6ea')
+    expect(
+      assetFingerprint(
+        '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+        '504154415445')
+    ).toEqual('asset13n25uv0yaf5kus35fm2k86cqy60z58d9xmde92')
+    expect(
+      assetFingerprint(
+        '1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209',
+        '504154415445')
+    ).toEqual('asset1hv4p5tv2a837mzqrst04d0dcptdjmluqvdx9k3')
+    expect(
+      assetFingerprint(
+        '1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209',
+        '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373')
+    ).toEqual('asset1aqrdypg669jgazruv5ah07nuyqe0wxjhe2el6f')
+    expect(
+      assetFingerprint(
+        '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+        '1e349c9bdea19fd6c147626a5260bc44b71635f398b67c59881df209')
+    ).toEqual('asset17jd78wukhtrnmjh3fngzasxm8rck0l2r4hhyyt')
+    expect(
+      assetFingerprint(
+        '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+        '0000000000000000000000000000000000000000000000000000000000000000'
+      )
+    ).toEqual('asset1pkpwyknlvul7az0xx8czhl60pyel45rpje4z8w')
+  })
+})


### PR DESCRIPTION
# Context

Fixes: #487

# Proposed Solution
- Pass empty string instead of `undefined` when `assetName` is not present.
- Verified using the CIP test vectors.
- Removes unnecessary jest scoping in `api-cardano-db-hasura` package script

# Important Changes Introduced

