### PR TITLE
chore: adds a workflow to sync a cardano-node-ogmios to cache the db

### DIFF
--- a/.github/actions/cardano-node-ogmios_docker_sync/action.yml
+++ b/.github/actions/cardano-node-ogmios_docker_sync/action.yml
@@ -1,0 +1,51 @@
+name: cardano-node-ogmios Docker sync
+description: Synchronize cardano-node-ogmios using Docker
+inputs:
+  containerName:
+    description: Docker container name
+    required: false
+    default: cardano-node-ogmios
+  dbDir:
+    description: Path to the host db mount
+    required: true
+  hostOgmiosPort:
+    description: Mapped host Ogmios port
+    required: false
+    default: 1337
+  repository:
+    description: Docker repository
+    required: false
+    default: cardanosolutions/cardano-node-ogmios
+  network:
+    description: Cardano network
+    required: true
+  version:
+    description: Ogmios version
+    required: false
+    default: latest
+runs:
+  using: composite
+  steps:
+    - name: 🔵 Set Docker Image
+      id: dockerImage
+      shell: bash
+      run: |
+        echo "::set-output name=value::${{ inputs.repository }}:${{ inputs.version }}-${{ inputs.network }}"
+
+    - name: 📥 Pull Image
+      run: |
+        docker pull ${{ steps.dockerImage.outputs.value }}
+      shell: bash
+
+    - name: ⟲ Sync
+      run: |
+        docker run --name ${{ inputs.containerName }} -p ${{ inputs.ogmiosPort }}:1337 -v ${{ inputs.dbDir }}:/db ${{ steps.dockerImage.outputs.value }}
+        ./scripts/wait-for-sync.sh ${{ inputs.ogmiosPort }} 1
+      shell: bash
+
+    - name: 🧹 Cleanup
+      run: |
+        docker stop ${{ inputs.containerName }}
+        docker rm ${{ inputs.containerName }}
+        docker rmi ${{ steps.dockerImage.outputs.value }}
+      shell: bash

--- a/.github/workflows/node_sync.yml
+++ b/.github/workflows/node_sync.yml
@@ -1,0 +1,39 @@
+name: Node Sync
+
+on:
+  schedule:
+    - cron: '00 06,18 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    strategy:
+      matrix:
+        network: [ mainnet ]
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v2.3.3
+
+      - name: ⌚ Get Date
+        id: date
+        shell: bash
+        run: |
+          echo "::set-output name=value::$(/bin/date -u "+%Y%m%d")"
+
+      - name: 💾 Cache node-db
+        id: cache
+        uses: actions/cache@v2.1.1
+        with:
+          path: ${{ runner.temp }}/db
+          key: cardano-node-${{ matrix.network }}-${{ steps.date.outputs.value }}
+          restore-keys: |
+            cardano-node-${{ matrix.network }}
+
+      - name: ⟲ Sync Node
+        uses: ./.github/actions/cardano-node-ogmios_docker_sync
+        with:
+          dbDir: ${{ runner.temp }}/db
+          network: ${{ matrix.network }}

--- a/scripts/wait-for-sync.sh
+++ b/scripts/wait-for-sync.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# wait-for-sync.sh
+#
+#   Wait for an ogmios / cardano-node to be synchronized with the network, up to a given threshold.
+#
+# Usage: ./wait-for-sync.sh OGMIOS_PORT THRESHOLD
+#
+# Examples:
+#   ./wait-for-sync.sh 1337 1
+#   ./wait-for-sync.sh 1338 0.95
+
+
+set -eo pipefail
+
+exitWithUsage () {
+  echo -e "Error: missing argument(s)!\n"
+  echo -e "Usage: $0 OGMIOS_PORT THRESHOLD"
+  echo -e "    Wait until a running Ogmios server at OGMIOS_PORT reaches THRESHOLD network synchronization.\n"
+  echo -e "Example: \n    $0 1338 0.95"
+  exit 1
+}
+
+OGMIOS_PORT=$1
+if [ -z "$OGMIOS_PORT" ]; then
+  exitWithUsage
+fi
+
+THRESHOLD=$2
+if [ -z "$THRESHOLD" ]; then
+  exitWithUsage
+fi
+
+URL=http://localhost:$OGMIOS_PORT/health
+
+showProgress () {
+  N="$1"
+  PER=$(printf "%.3f\n" "$(bc <<< "$N * 100")")
+  LEN=$(printf "%.0f\n" "$(bc <<< "$N * 50")")
+
+  BAR=""
+  for ((i=1; i<=$LEN; i++))
+  do
+    BAR="$BAR▣"
+  done
+  for ((i=$LEN; i<=50; i++))
+  do
+    BAR="$BAR "
+  done
+
+  echo -en "Network synchronization: [$BAR] $PER%\r"
+}
+
+for (( ;; ))
+do
+  HEALTH=$(curl -sS $URL)
+  NETWORK_SYNCHRONIZATION=$(sed 's/.*"networkSynchronization":\([0-9]\+\.\?[0-9]*\).*/\1/' <<< $HEALTH)
+
+  RE='^[0-9]+\.?[0-9]*$'
+  if ! [[ $NETWORK_SYNCHRONIZATION =~ $RE ]] ; then
+     echo "error: unexpected response from /health endpoint: $HEALTH"
+     exit 1
+  fi
+
+  showProgress $NETWORK_SYNCHRONIZATION
+  PREDICATE=$(bc <<< "$NETWORK_SYNCHRONIZATION >= $THRESHOLD")
+
+  if [ "$PREDICATE" -eq 1 ]; then
+    exit 0
+  else
+    sleep 5
+  fi
+done


### PR DESCRIPTION
# Context
This is preparation to complete the Jenkins migration to GitHub Actions. The local action will be replaced by a GitHub marketplace reference when available.

# Proposed Solution
Uses cron-triggered workflow to maintain a `cardano-node` mainnet db cache, which can then be accessed in CI and other workflows. It can also be triggered manually.  

# Important Changes Introduced
NA
