### PR TITLE
feature: submitTransaction error mapping

### DIFF
--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -12,10 +12,6 @@ import {
 import { dummyLogger, Logger } from 'ts-log'
 import { getHashOfSignedTransaction } from './util'
 
-const isEraMismatch = (errorMessage: string): boolean =>
-  errorMessage.includes('DecoderErrorDeserialiseFailure') ||
-  errorMessage.includes('The era of the node and the tx do not match')
-
 const MODULE_NAME = 'CardanoNodeClient'
 
 export class CardanoNodeClient {
@@ -107,15 +103,9 @@ export class CardanoNodeClient {
     if (this.state !== 'initialized') {
       throw new errors.ModuleIsNotInitialized(MODULE_NAME, 'submitTransaction')
     }
-    try {
-      await this.txSubmissionClient.submitTx(transaction)
-      const hash = getHashOfSignedTransaction(transaction)
-      this.logger.info({ module: MODULE_NAME, hash }, 'submitTransaction')
-      return hash
-    } catch (error) {
-      if (!isEraMismatch(error.message)) {
-        throw error
-      }
-    }
+    await this.txSubmissionClient.submitTx(transaction)
+    const hash = getHashOfSignedTransaction(transaction)
+    this.logger.info({ module: MODULE_NAME, hash }, 'submitTransaction')
+    return hash
   }
 }

--- a/packages/api-cardano-db-hasura/src/executableSchema.ts
+++ b/packages/api-cardano-db-hasura/src/executableSchema.ts
@@ -89,11 +89,16 @@ export async function buildSchema (
               )
               return { hash }
             } catch (error) {
-              throw new ApolloError(
-                error.name === 'ModuleIsNotInitialized'
-                  ? 'submitTransaction query is not ready. Try again shortly'
-                  : error.message
-              )
+              if (Array.isArray(error)) {
+                throw new ApolloError('Invalid Transaction', 'BAD_REQUEST', {
+                  reasons: error.map(e => ({
+                    name: e.name,
+                    details: JSON.parse(e.message)
+                  }))
+                })
+              } else {
+                throw new ApolloError(error)
+              }
             }
           },
           selectionSet: null,


### PR DESCRIPTION
# Context
User input errors need to be thrown from resolvers as a single `ApolloError`, but the Ogmios transaction submission client returns an array of errors that is currently not presented well. There is also some legacy logic left from a previous refactor to be cleaned up.

# Proposed Solution
- removes legacy cardano-cli `isEraMismatch` logic
- reduces the array of errors from the Ogmios client to a single `ApolloError`,
with the individual errors mapped into the extension field.

# Important Changes Introduced
Transaction submission errors are now present in the extensions eg:

``` json
{
  "errors": [
    {
      "message": "Invalid Transaction",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "submitTransaction"
      ],
      "extensions": {
        "reasons": [
          {
            "name": "ValueNotConservedError",
            "details": {
              "consumed": {
                "coins": 0,
                "assets": {}
              },
              "produced": {
                "coins": 501000000,
                "assets": {}
              }
            }
          },
          {
            "name": "NetworkMismatchError",
            "details": {
              "expectedNetwork": "mainnet",
              "invalidEntities": [
                {
                  "type": "address",
                  "entity": "addr_test1qqm8k5xpnx647etjxxexd40hk0cgv7vz64fj9l3ldhtzh6wss5ftcx6ppfxak3ydjjm06q6kqprfu38fqdc7fr5xqy6sjylyx4"
                },
                {
                  "type": "address",
                  "entity": "addr_test1qr9v4z950pl4agmehnr632g5z7yd7pk2zlmzaazam4uvumkss5ftcx6ppfxak3ydjjm06q6kqprfu38fqdc7fr5xqy6slg87v7"
                }
              ]
            }
          },
          {
            "name": "BadInputsError",
            "details": [
              {
                "txId": "7bd1f6298fe2dd376a5cb37e42f4156c051741176e16c56bf66112b2548b9be3",
                "index": 0
              },
              {
                "txId": "bbb67e2f6597d141b58adb33330d7db00a8832a7a49ce783d2429e26a7d51111",
                "index": 0
              }
            ]
          },
          {
            "name": "FeeTooSmallError",
            "details": {
              "requiredFee": 183805,
              "actualFee": 181473
            }
          }
        ],
        "code": "BAD_REQUEST",
        "exception": {
          "reasons": [
            {
              "name": "ValueNotConservedError",
              "details": {
                "consumed": {
                  "coins": 0,
                  "assets": {}
                },
                "produced": {
                  "coins": 501000000,
                  "assets": {}
                }
              }
            },
            {
              "name": "NetworkMismatchError",
              "details": {
                "expectedNetwork": "mainnet",
                "invalidEntities": [
                  {
                    "type": "address",
                    "entity": "addr_test1qqm8k5xpnx647etjxxexd40hk0cgv7vz64fj9l3ldhtzh6wss5ftcx6ppfxak3ydjjm06q6kqprfu38fqdc7fr5xqy6sjylyx4"
                  },
                  {
                    "type": "address",
                    "entity": "addr_test1qr9v4z950pl4agmehnr632g5z7yd7pk2zlmzaazam4uvumkss5ftcx6ppfxak3ydjjm06q6kqprfu38fqdc7fr5xqy6slg87v7"
                  }
                ]
              }
            },
            {
              "name": "BadInputsError",
              "details": [
                {
                  "txId": "7bd1f6298fe2dd376a5cb37e42f4156c051741176e16c56bf66112b2548b9be3",
                  "index": 0
                },
                {
                  "txId": "bbb67e2f6597d141b58adb33330d7db00a8832a7a49ce783d2429e26a7d51111",
                  "index": 0
                }
              ]
            },
            {
              "name": "FeeTooSmallError",
              "details": {
                "requiredFee": 183805,
                "actualFee": 181473
              }
            }
          ]
        }
      }
    }
  ],
  "data": null
}
```

The duplication in the `exception` property is a [known issue](https://github.com/apollographql/apollo-server/issues/3835) with `ApolloError`