### PR TITLE
Fix HasuraClient trying to return above 100%

### DIFF
--- a/packages/api-cardano-db-hasura/src/HasuraClient.ts
+++ b/packages/api-cardano-db-hasura/src/HasuraClient.ts
@@ -482,12 +482,14 @@ export class HasuraClient {
     )
     const { tip } = result?.cardano[0]
     const lastEpoch = result?.epochs[0]
+    const syncPercentage = tip.slotNo / nodeTipSlotNumber * 100
     return {
       // cardano-db-sync writes the epoch record at the end of each epoch during times of bulk sync
       // The initialization state can be determined by comparing the last epoch record against the
       // tip
       initialized: lastEpoch.number === tip.epoch?.number,
-      syncPercentage: (tip.slotNo / nodeTipSlotNumber) * 100
+      // we cannot assume that actual db-sync syncPercentage will be less or equal to node sync state due to race condition at the query time
+      syncPercentage: syncPercentage > 100 ? 100 : syncPercentage
     }
   }
 


### PR DESCRIPTION
# Context

Fixes #542

Query
`{ cardanoDbMeta { syncPercentage }} `
was resulting in error for values like `100.0060734062478`
`{
  "errors": [
    {
      "message": "Percentage must be a number between 0 - 100.00",
      "locations": [
        {
          "line": 4,
          "column": 5
        }
      ],
      "path": [
        "cardanoDbMeta",
        "syncPercentage"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR",
        "exception": {
          "stacktrace": [
            "TypeError: Percentage must be a number between 0 - 100.00",
            "    at GraphQLScalarType.serialize (/app/packages/util/dist/scalars/Percentage.js:15:19)",
            "    at completeLeafValue (/app/node_modules/graphql/execution/execute.js:635:37)",
            "    at completeValue (/app/node_modules/graphql/execution/execute.js:579:12)",
            "    at completeValue (/app/node_modules/graphql/execution/execute.js:557:21)",
            "    at completeValueCatchingError (/app/node_modules/graphql/execution/execute.js:495:19)",
            "    at resolveField (/app/node_modules/graphql/execution/execute.js:435:10)",
            "    at executeFields (/app/node_modules/graphql/execution/execute.js:275:18)",
            "    at collectAndExecuteSubfields (/app/node_modules/graphql/execution/execute.js:713:10)",
            "    at completeObjectValue (/app/node_modules/graphql/execution/execute.js:703:10)",
            "    at completeValue (/app/node_modules/graphql/execution/execute.js:591:12)"
          ]
        }
      }
    }
  ],
  "data": null
}`


# Proposed Solution

Set a `100` max threshold for returned `syncPercentage` value in `HasuraClient.ts`

# Important Changes Introduced

