### PR TITLE
Feature/disable query complexity with allow list

### DIFF
--- a/nix/nixos/cardano-graphql-service.nix
+++ b/nix/nixos/cardano-graphql-service.nix
@@ -127,6 +127,10 @@ in {
         type = lib.types.nullOr lib.types.int;
         default = null;
       };
+      maxQueryComplexity = lib.mkOption {
+        type = lib.types.nullOr lib.types.int;
+        default = null;
+      };
     };
   };
   config = let
@@ -177,7 +181,8 @@ in {
       (lib.optionalAttrs (cfg.pollingIntervalAdaSupply != null) { POLLING_INTERVAL_ADA_SUPPLY = toString cfg.pollingIntervalAdaSupply; }) //
       (lib.optionalAttrs (cfg.assetMetadataUpdateInterval != null) { ASSET_METADATA_UPDATE_INTERVAL = toString cfg.assetMetadataUpdateInterval; }) //
       (lib.optionalAttrs (cfg.queryDepthLimit != null) { QUERY_DEPTH_LIMIT = toString cfg.queryDepthLimit; }) //
-      (lib.optionalAttrs (cfg.allowListPath != null) { ALLOW_LIST_PATH = cfg.allowListPath; });
+      (lib.optionalAttrs (cfg.allowListPath != null) { ALLOW_LIST_PATH = cfg.allowListPath; }) //
+      (lib.optionalAttrs (cfg.maxQueryComplexity != null) { MAX_QUERY_COMPLEXITY = toString cfg.maxQueryComplexity; });
       path = with pkgs; [ netcat curl postgresql frontend hasura-cli glibc.bin patchelf ];
       preStart = ''
         set -exuo pipefail

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -10,7 +10,11 @@ import http from 'http'
 import { listenPromise } from './util'
 import { AllowList } from './AllowList'
 import { prometheusMetricsPlugin, queryComplexityPlugin } from './apollo_server_plugins'
-import { IntrospectionNotPermitted, TracingRequired } from './errors'
+import {
+  IntrospectionNotPermitted,
+  QueryComplexityLimitationNotPermitted,
+  TracingRequired
+} from './errors'
 import { allowListMiddleware } from './express_middleware'
 import { dummyLogger, Logger } from 'ts-log'
 import { setIntervalAsync, SetIntervalAsyncTimer } from 'set-interval-async/dynamic'
@@ -61,6 +65,9 @@ export class Server {
     if (this.config.allowListPath) {
       if (this.config.allowIntrospection === true) {
         throw new IntrospectionNotPermitted('allowListPath')
+      }
+      if (this.config.maxQueryComplexity) {
+        throw new QueryComplexityLimitationNotPermitted('allowListPath')
       }
       try {
         const file = await fs.readFile(this.config.allowListPath, 'utf8')

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -62,7 +62,7 @@ export async function getConfig (): Promise<Config> {
     db,
     loggerMinSeverity: env.loggerMinSeverity || 'info' as LogLevelString,
     listenAddress: env.listenAddress || '0.0.0.0',
-    maxQueryComplexity: env.maxQueryComplexity || 5000,
+    maxQueryComplexity: env.maxQueryComplexity,
     pollingInterval: {
       adaSupply: env.pollingInterval.adaSupply || 1000 * 60
     },

--- a/packages/server/src/errors/QueryComplexityLimitationNotPermitted.ts
+++ b/packages/server/src/errors/QueryComplexityLimitationNotPermitted.ts
@@ -1,0 +1,8 @@
+import { CustomError } from 'ts-custom-error'
+
+export class QueryComplexityLimitationNotPermitted extends CustomError {
+  public constructor (conflictingOption: string) {
+    super()
+    this.message = `Query complexity limitation is not permitted while ${conflictingOption} is enabled`
+  }
+}

--- a/packages/server/src/errors/index.ts
+++ b/packages/server/src/errors/index.ts
@@ -1,4 +1,5 @@
 export * from './IntrospectionNotPermitted'
 export * from './MissingConfig'
+export * from './QueryComplexityLimitationNotPermitted'
 export * from './QueryTooComplex'
 export * from './TracingRequired'


### PR DESCRIPTION
# Context
Limiting query complexity is a conflicting concept when the allow list is enabled. It also is better to be opt-in, rather than a relaxed value since that can produce unexpected rejections and causes unnecessary performance overhead when not desired.

# Proposed Solution
1. Remove the default
2. Throw an error if used in conjunction with an allow list

# Important Changes Introduced
I've also added the nix config to support query complexity limitation.