### PR TITLE
feature: adds scripts to simplify up and down commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,28 @@ git clone \
   && cd cardano-graphql
 ```
 ### Build and Run via Docker Compose
-Builds `@cardano-graphql/server` and starts it along with `cardano-ogmios-node`, `cardano-db-sync-extended`, `postgresql`, and `hasura`:
 
 ``` console
-DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose up -d --build && docker-compose logs -f
+./scripts/up.sh --use-cache
 ```
-:information_source: _Omit the `--build` to use a pre-built image from Dockerhub (or locally cached from previous build)_
+:information_source: _See [docker-compose.yaml](./docker-compose.yml) for service details_
+
+#### Config
+- `--use-cache`: Access remote cache from [Docker Hub]
+- `NETWORK`: [See available networks](../ogmios/server/config)
+- `API_PORT`: GraphQL port exposed on the host
+- `OGMIOS_PORT`: Ogmios port exposed on the host
+- `POSTGRES_PORT`: PostgreSQL port exposed on the host
+
+:information_source: _Set the ENVs before the script_
+
+## Down
+``` console
+./scripts/down.sh
+```
+#### Config
+- `NETWORK`: As provided to the `up` script.
+
 ### Check Cardano DB sync progress
 Use the GraphQL Playground in the browser at http://localhost:3100/graphql:
 ``` graphql 
@@ -122,6 +138,7 @@ See [Building].
 [available on npm]: https://www.npmjs.com/package/cardano-graphql-ts
 [Ogmios]: https://ogmios.dev/
 [releases]: https://github.com/input-output-hk/cardano-graphql/releases
+[Docker Hub]: https://hub.docker.com/repository/docker/cardanosolutions/cardano-node-ogmios
 [Wiki :book:]: https://github.com/input-output-hk/cardano-graphql/wiki
 [Using Docker]: https://github.com/input-output-hk/cardano-graphql/wiki/Docker
 [Building]: https://github.com/input-output-hk/cardano-graphql/wiki/Building

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ git clone \
 ``` console
 ./scripts/up.sh --use-cache
 ```
-:information_source: _See [docker-compose.yaml](./docker-compose.yml) for service details_
+:information_source: _This is a small convenience script to boot the [docker-compose stack] with a convention for
+container and volume scoping based on the network, as well as optionally hitting the remote cache to speed up the build.
+Should this not suit your use-case simply use it as a reference along with the [Docker Compose docs]_
 
 #### Config
 - `--use-cache`: Access remote cache from [Docker Hub]
@@ -138,6 +140,7 @@ See [Building].
 [available on npm]: https://www.npmjs.com/package/cardano-graphql-ts
 [Ogmios]: https://ogmios.dev/
 [releases]: https://github.com/input-output-hk/cardano-graphql/releases
+[Docker Compose docs]: https://docs.docker.com/compose/
 [Docker Hub]: https://hub.docker.com/repository/docker/cardanosolutions/cardano-node-ogmios
 [Wiki :book:]: https://github.com/input-output-hk/cardano-graphql/wiki
 [Using Docker]: https://github.com/input-output-hk/cardano-graphql/wiki/Docker

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git clone \
 
 #### Config
 - `--use-cache`: Access remote cache from [Docker Hub]
-- `NETWORK`: [See available networks](../ogmios/server/config)
+- `NETWORK`: [See available networks](./ogmios/server/config)
 - `API_PORT`: GraphQL port exposed on the host
 - `OGMIOS_PORT`: Ogmios port exposed on the host
 - `POSTGRES_PORT`: PostgreSQL port exposed on the host

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git clone \
 
 #### Config
 - `--use-cache`: Access remote cache from [Docker Hub]
-- `NETWORK`: [See available networks](./ogmios/server/config)
+- `NETWORK`: `testnet` | `alonzo-purple`
 - `API_PORT`: GraphQL port exposed on the host
 - `OGMIOS_PORT`: Ogmios port exposed on the host
 - `POSTGRES_PORT`: PostgreSQL port exposed on the host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,11 +95,12 @@ services:
 
   cardano-graphql:
     build:
-      context: .
-      target: server
       args:
         - NETWORK=${NETWORK:-mainnet}
         - METADATA_SERVER_URI=${METADATA_SERVER_URI:-https://tokens.cardano.org}
+      cache_from: [ inputoutput/cardano-graphql:latest ]
+      context: .
+      target: server
     image: inputoutput/cardano-graphql:${CARDANO_GRAPHQL_VERSION:-5.0.0}
     environment:
       - ALLOW_INTROSPECTION=true

--- a/scripts/down.sh
+++ b/scripts/down.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export NETWORK=${NETWORK:-mainnet}
+
+docker-compose -p $NETWORK down

--- a/scripts/down.sh
+++ b/scripts/down.sh
@@ -2,6 +2,4 @@
 
 set -euo pipefail
 
-export NETWORK=${NETWORK:-mainnet}
-
-docker-compose -p $NETWORK down
+docker-compose -p ${NETWORK:-mainnet} down

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -7,11 +7,17 @@ export API_PORT=${API_PORT:-3100}
 export OGMIOS_PORT=${OGMIOS_PORT:-1337}
 export POSTGRES_PORT=${POSTGRES_PORT:-5433}
 
-if [[ $1 ]]; then
-  # Docker Buildkit
-  export DOCKER_BUILDKIT=1
-  export COMPOSE_DOCKER_CLI_BUILD=1
-fi
+while [[ "$#" -gt 0 ]]
+do
+  case $1 in
+    --use-cache)
+      # Docker Buildkit
+      export DOCKER_BUILDKIT=1
+      export COMPOSE_DOCKER_CLI_BUILD=1
+      ;;
+  esac
+  shift
+done
 
 docker-compose -p $NETWORK up -d --build && \
 docker-compose -p $NETWORK logs -f

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+export NETWORK=${NETWORK:-mainnet}
+export API_PORT=${API_PORT:-3100}
+export OGMIOS_PORT=${OGMIOS_PORT:-1337}
+export POSTGRES_PORT=${POSTGRES_PORT:-5433}
+
+if [[ $1 ]]; then
+  # Docker Buildkit
+  export DOCKER_BUILDKIT=1
+  export COMPOSE_DOCKER_CLI_BUILD=1
+fi
+
+docker-compose -p $NETWORK up -d --build && \
+docker-compose -p $NETWORK logs -f


### PR DESCRIPTION
# Context
The native Docker commands along with the Docker Buildkit host config are a
little verbose, and do not present an amazing interface for end-users. 

# Proposed Solution
This PR adds two convenience scripts to simplify the startup and teardown of the
stack with the docker-compose ENVs exposed. The use of the cache is opt-in
but is used in the documented invocation.

# Important Changes Introduced
N/A

## Test clone command:
```
git clone \
  --single-branch \
  --branch feature/up-down-script \
  --recurse-submodules \
  https://github.com/input-output-hk/cardano-graphql.git \
  && cd cardano-graphql
  ```
