### PR TITLE
Chore/mainnet suffixed docker image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,18 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      -  
-        name: Checkout source code
+      - name: 📥 Checkout repository
         uses: actions/checkout@v2.3.1
-      -
-        name: Setup Node.js
+      
+      - name: 🧰 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        
+      - name: 🧰 Setup Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 14
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Compile TypeScript and lint
+        
+      - name: 🔨 Compile TypeScript and lint
         run: |
           yarn install --offline --frozen-lockfile --non-interactive --logevel=error
           yarn build
@@ -30,16 +29,16 @@ jobs:
           ALLOW_INTROSPECTION: true
           CACHE_ENABLED: false
           CARDANO_GRAPHQL_VERSION: ${{ github.sha }}
-      -
-        name: Build Cardano GraphQL Dockerfile
+          
+      - name: 🔨 Build Cardano GraphQL Server Dockerfile
         uses: docker/build-push-action@v2
         with:
           cache-from: type=registry,ref=inputoutput/cardano-graphql:master
           cache-to: type=inline
           tags: inputoutput/cardano-graphql:${{ github.sha }}
           target: server
-      -
-        name: Build Cardano GraphQL Hasura Dockerfile
+          
+      - name: 🔨 Build Cardano GraphQL Hasura Dockerfile
         uses: docker/build-push-action@v2
         with:
           context: ./packages/api-cardano-db-hasura/hasura

--- a/.github/workflows/post_integration.yml
+++ b/.github/workflows/post_integration.yml
@@ -7,34 +7,63 @@ on:
 
 jobs:
   push-docker-build:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        network: [ "mainnet", "testnet", "alonzo-purple" ]
+
+    runs-on: ${{ matrix.os }}
     steps:
-      -
-        name: Checkout source code
+      - name: 📥 Checkout repository
         uses: actions/checkout@v2.3.1
-      -
-        name: Set up Docker Buildx
+        
+      - name: 🧰 Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to Docker Hub
+        
+      - name: 🐳 Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      -
-        name: Build and push Cardano GraphQL Dockerfile
+
+      - name: 📝 Base Variables
+        id: base-variables
+        run: |
+          echo ::set-output name=cardano-graphql-server-image::inputoutput/cardano-graphql
+          echo ::set-output name=cardano-graphql-hasura-image::inputoutput/cardano-graphql-hasura
+
+      - name: 🔨 Build and push Cardano GraphQL Server Dockerfile (default latest)
+        if: ${{ matrix.network == 'mainnet' }}
         uses: docker/build-push-action@v2
         with:
-          cache-from: type=registry,ref=inputoutput/cardano-graphql:master
-          cache-to: type=inline
+          build-args: NETWORK=${{ matrix.network }}
+          context: .
           push: true
-          tags: inputoutput/cardano-graphql:${{ github.sha }}, inputoutput/cardano-graphql:master
+          tags: ${{ steps.base-variables.outputs.cardano-graphql-server-image }}:latest
           target: server
-      -
-        name: Build and push Cardano GraphQL Hasura Dockerfile
+          cache-from: type=registry,ref=${{ steps.base-variables.outputs.cardano-graphql-server-image }}:latest
+          cache-to: type=inline
+      
+      - name: 🔨 Build and push Cardano GraphQL Server Dockerfile (network latest)
         uses: docker/build-push-action@v2
         with:
+          build-args: NETWORK=${{ matrix.network }}
+          context: .
+          push: true
+          tags: ${{ steps.base-variables.outputs.cardano-graphql-server-image }}:latest-${{ matrix.network }}
+          target: server
+          cache-from: type=registry,ref=${{ steps.base-variables.outputs.cardano-graphql-server-image }}:master-${{ matrix.network }}
+          cache-to: type=inline
+      
+      - name: 🔨 Build and push Cardano GraphQL Hasura Dockerfile (network latest)
+        uses: docker/build-push-action@v2
+        with:
+          build-args: NETWORK=${{ matrix.network }}
           context: ./packages/api-cardano-db-hasura/hasura
           file: ./packages/api-cardano-db-hasura/hasura/Dockerfile
           push: true
-          tags: inputoutput/cardano-graphql-hasura:${{ github.sha }}, inputoutput/cardano-graphql-hasura:master
+          tags: ${{ steps.base-variables.outputs.cardano-graphql-hasura-image }}:latest-${{ matrix.network }}
+          target: server
+          cache-from: type=registry,ref=${{ steps.base-variables.outputs.cardano-graphql-hasura-image }}:master-${{ matrix.network }}
+          cache-to: type=inline    
+          

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -7,58 +7,80 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+        network: [ "mainnet", "testnet", "alonzo-purple" ]
+        
+    runs-on: ${{ matrix.os }}
     steps:
-      -
-        name: Checkout source code
+      - name: 📥 Checkout repository
         uses: actions/checkout@v2.3.1
-      -
-        name: Setup Node.js
+
+      - name: 🧰 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: 🧰 Setup Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 14
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to Docker Hub
+
+      - name: 🐳 Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      -
-        name: Build and push Cardano GraphQL Dockerfile
+          
+      - name: 📝 Base Variables
+        id: base-variables
+        run: |
+          echo ::set-output name=cardano-graphql-server-image::inputoutput/cardano-graphql
+          echo ::set-output name=cardano-graphql-hasura-image::inputoutput/cardano-graphql-hasura
+          
+      - name: 🔨 Build and push Cardano GraphQL Server Dockerfile (default)
+        if: ${{ matrix.network == 'mainnet' }}
         uses: docker/build-push-action@v2
         with:
-          push: true
-          tags: inputoutput/cardano-graphql:${{ github.sha }}, inputoutput/cardano-graphql:${{ github.event.release.tag_name }}, inputoutput/cardano-graphql:latest
-          cache-from: type=registry,ref=inputoutput/cardano-graphql:master
+          cache-from: type=registry,ref=${{ steps.base-variables.outputs.cardano-graphql-server-image }}:latest
           cache-to: type=inline
-      -
-        name: Build and push Cardano GraphQL Hasura Dockerfile
+          push: true
+          tags: ${{ steps.base-variables.outputs.cardano-graphql-server-image }}:${{ github.sha }}, ${{ steps.base-variables.outputs.cardano-graphql-server-image }}:${{ github.event.release.tag_name }}, ${{ steps.base-variables.outputs.cardano-graphql-server-image }}:latest
+          target: server
+      
+      - name: 🔨 Build and push Cardano GraphQL Server Dockerfile (network tags)
+        uses: docker/build-push-action@v2
+        with:
+          build-args: NETWORK=${{ matrix.network }}
+          cache-from: type=registry,ref=${{ steps.base-variables.outputs.cardano-graphql-server-image }}:latest
+          cache-to: type=inline
+          push: true
+          tags: ${{ steps.base-variables.outputs.cardano-graphql-server-image }}:${{ github.sha }}-${{ matrix.network }}, ${{ steps.base-variables.outputs.cardano-graphql-server-image }}:${{ github.event.release.tag_name }}-${{ matrix.network }}, ${{ steps.base-variables.outputs.cardano-graphql-server-image }}:latest-${{ matrix.network }}
+          target: server
+          
+      - name: 🔨 Build and push Cardano GraphQL Hasura Dockerfile
         uses: docker/build-push-action@v2
         with:
           context: ./packages/api-cardano-db-hasura/hasura
           file: ./packages/api-cardano-db-hasura/hasura/Dockerfile
           push: true
-          tags: inputoutput/cardano-graphql-hasura:${{ github.sha }}, inputoutput/cardano-graphql-hasura:${{ github.event.release.tag_name }}, inputoutput/cardano-graphql-hasura:latest
-      -
-        name: Publish packages to npm registry
+          tags: ${{ steps.base-variables.outputs.cardano-graphql-hasura-image }}:${{ github.sha }}, inputoutput/cardano-graphql-hasura:${{ github.event.release.tag_name }}, inputoutput/cardano-graphql-hasura:latest
+      
+      - name: 📤 Publish packages to npm registry
         run: |
           yarn install --offline --frozen-lockfile --non-interactive --logevel=error
           npx npm-cli-login -u ${{ secrets.NPM_REGISTRY_USER }} -e ${{ secrets.NPM_REGISTRY_EMAIL }} -p ${{ secrets.NPM_REGISTRY_TOKEN }}
           scripts/publish_packages.sh
         if: ${{ always() }}
           rm -f .npmrc
-      -
-        name: Build docs
+        
+      - name: 🔨 Build docs
         run: |
           yarn --cwd ./docs install --frozen-lockfile
           yarn --cwd ./docs build
         env:
           SKIP_PREFLIGHT_CHECK: true
-      -
-        name: Deploy
+          
+      - name: 📤 Deploy
         uses: JamesIves/github-pages-deploy-action@4.0.0
         with:
           branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ your use-case.
   <summary><i>mainnet</i></summary>
 
 ``` console
-docker-compose pull &&\
+export NETWORK=mainnet &&\
+docker pull inputoutput/cardano-graphql:5.1.0-beta.1-${NETWORK} &&\
+docker pull inputoutput/cardano-graphql-hasura:5.1.0-beta.1 &&\
+docker pull cardanosolutions/cardano-node-ogmios:v4.0.0-beta.6-${NETWORK} &&\
 docker-compose up -d &&\
 docker-compose logs -f
 ```
@@ -120,13 +123,15 @@ docker-compose logs -f
 
 ``` console
 export NETWORK=testnet &&\
-docker-compose pull &&\
+docker pull inputoutput/cardano-graphql:5.1.0-beta.1-${NETWORK} &&\
+docker pull inputoutput/cardano-graphql-hasura:5.1.0-beta.1 &&\
+docker pull cardanosolutions/cardano-node-ogmios:v4.0.0-beta.6-${NETWORK} &&\
 API_PORT=3101 \
 HASURA_PORT=8091 \
 OGMIOS_PORT=1338 \
 POSTGRES_PORT=5433 \
-docker-compose -p testnet up -d &&\
-docker-compose -p testnet logs -f
+docker-compose -p ${NETWORK} up -d &&\
+docker-compose -p ${NETWORK} logs -f
 ```
 
 </details>
@@ -136,13 +141,15 @@ docker-compose -p testnet logs -f
 
 ``` console
 export NETWORK=alonzo-purple &&\
-docker-compose pull &&\
+docker pull inputoutput/cardano-graphql:5.1.0-beta.1-${NETWORK} &&\
+docker pull inputoutput/cardano-graphql-hasura:5.1.0-beta.1 &&\
+docker pull cardanosolutions/cardano-node-ogmios:v4.0.0-beta.6-${NETWORK} &&\
 API_PORT=3102 \
 HASURA_PORT=8092 \
 OGMIOS_PORT=1339 \
 POSTGRES_PORT=5434 \
-docker-compose -p alonzo-purple up -d &&\
-docker-compose -p alonzo-purple logs -f
+docker-compose -p ${NETWORK} up -d &&\
+docker-compose -p ${NETWORK} logs -f
 ```
 
 </details>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       cache_from: [ inputoutput/cardano-graphql:latest ]
       context: .
       target: server
-    image: inputoutput/cardano-graphql:${CARDANO_GRAPHQL_VERSION:-5.1.0-beta.1}
+    image: inputoutput/cardano-graphql:${CARDANO_GRAPHQL_VERSION:-5.1.0-beta.1}-${NETWORK:-mainnet}
     environment:
       - ALLOW_INTROSPECTION=true
       - CACHE_ENABLED=true


### PR DESCRIPTION
# Context
The current Docker repository does not have mainnet suffixed tags and the docker-compose file always uses the _mainnet_. To support all available networks the registry needs to contain `-mainnet` images in addition to the default tags, so an ENV can be used.
  
# Proposed Solution
Pushes `-mainnet` suffixed images, and adds the ENV.

# Important Changes Introduced

