### PR TITLE
db-sync docker image: stateDir no longer available.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-        
+
   cardano-node-ogmios:
     build:
       args:
@@ -42,13 +42,12 @@ services:
     volumes:
       - node-db:/db
       - node-ipc:/ipc
-    
+
   cardano-db-sync-extended:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-11.0.0}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-11.0.2}
     command: [
       "--config", "/config/cardano-db-sync/config.json",
-      "--socket-path", "/node-ipc/node.socket",
-      "--state-dir", "/data"
+      "--socket-path", "/node-ipc/node.socket"
     ]
     environment:
       - EXTENDED=true
@@ -63,7 +62,7 @@ services:
       - postgres_db
     volumes:
       - ./config/network/${NETWORK:-mainnet}:/config
-      - db-sync-data:/data
+      - db-sync-data:/var/lib/cdbsync
       - node-ipc:/node-ipc
     restart: on-failure
     logging:
@@ -71,7 +70,7 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
-        
+
   hasura:
     build:
       context: ./packages/api-cardano-db-hasura/hasura


### PR DESCRIPTION
In order to properly support snapshot restoration, the state directory has been fixed in the latest db-sync docker image, and thus is no longer available as an option.