### PR TITLE
feature: include all reward types in Reward model, adds `type` field

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -149,10 +149,10 @@ SELECT
   reward.amount,
   stake_address.view AS "address",
   reward.earned_epoch AS "earnedInEpochNo",
-  reward.pool_id AS pool_hash_id
+  reward.pool_id AS pool_hash_id,
+  reward.type AS "type"
 FROM reward
-JOIN stake_address on reward.addr_id = stake_address.id
-WHERE type = 'member';
+JOIN stake_address on reward.addr_id = stake_address.id;
 
 CREATE VIEW "Script" AS
 SELECT

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -609,7 +609,8 @@ type Reward {
   address: StakeAddress!
   amount: String!
   earnedIn: Epoch!
-  stakePool: StakePool!
+  stakePool: StakePool
+  type: String!
 }
 
 type Reward_aggregate {
@@ -648,6 +649,7 @@ input Reward_bool_exp {
   amount: text_comparison_exp
   earnedIn: Epoch_bool_exp
   stakePool: StakePool_bool_exp
+  type: text_comparison_exp
 }
 
 input Reward_order_by {
@@ -655,6 +657,7 @@ input Reward_order_by {
   amount: order_by
   earnedIn: Epoch_order_by
   stakePool: StakePool_order_by
+  type: order_by
 }
 
 type Script {

--- a/packages/api-cardano-db-hasura/src/example_queries/rewards/rewardsForAddress.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/rewards/rewardsForAddress.graphql
@@ -11,5 +11,6 @@ query rewardsForAddress (
         earnedIn {
             number
         }
+        type
     }
 }

--- a/packages/api-cardano-db-hasura/test/rewards.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/rewards.query.test.ts
@@ -25,6 +25,7 @@ describe('rewards', () => {
     expect(rewards.length).toBe(5)
     expect(rewards[0].stakePool.hash).toBeDefined()
     expect(rewards[0].earnedIn.number).toBeDefined()
+    expect(rewards[0].type).toBeDefined()
   })
 
   it('can return aggregated data on all delegations', async () => {


### PR DESCRIPTION
# Context
Closes #550 Closes #588 Closes #592

# Proposed Solution
Includes all reward types in the Reward view.

# Important Changes Introduced

BREAKING CHANGE: `Reward.stakePool` is now nullable to handle rewards of type
`treasury` or `reserves`.