### PR TITLE
feature: `Reward.receivedIn`

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
+++ b/packages/api-cardano-db-hasura/hasura/project/metadata/tables.yaml
@@ -435,6 +435,14 @@
           name: Epoch
         column_mapping:
           earnedInEpochNo: number
+  - name: receivedIn
+    using:
+      manual_configuration:
+        remote_table:
+          schema: public
+          name: Epoch
+        column_mapping:
+          receivedInEpochNo: number
   - name: stakePool
     using:
       manual_configuration:

--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -150,6 +150,7 @@ SELECT
   stake_address.view AS "address",
   reward.earned_epoch AS "earnedInEpochNo",
   reward.pool_id AS pool_hash_id,
+  reward.spendable_epoch AS "receivedInEpochNo",
   reward.type AS "type"
 FROM reward
 JOIN stake_address on reward.addr_id = stake_address.id;

--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -609,6 +609,7 @@ type Reward {
   address: StakeAddress!
   amount: String!
   earnedIn: Epoch!
+  receivedIn: Epoch!
   stakePool: StakePool
   type: String!
 }
@@ -648,6 +649,7 @@ input Reward_bool_exp {
   address: StakeAddress_comparison_exp
   amount: text_comparison_exp
   earnedIn: Epoch_bool_exp
+  receivedIn: Epoch_bool_exp
   stakePool: StakePool_bool_exp
   type: text_comparison_exp
 }
@@ -656,6 +658,7 @@ input Reward_order_by {
   address: order_by
   amount: order_by
   earnedIn: Epoch_order_by
+  receivedIn: Epoch_order_by
   stakePool: StakePool_order_by
   type: order_by
 }

--- a/packages/api-cardano-db-hasura/src/example_queries/rewards/rewardsForAddress.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/rewards/rewardsForAddress.graphql
@@ -11,6 +11,9 @@ query rewardsForAddress (
         earnedIn {
             number
         }
+        receivedIn {
+            number
+        }
         type
     }
 }

--- a/packages/api-cardano-db-hasura/src/example_queries/stake_pools/allStakePoolFields.graphql
+++ b/packages/api-cardano-db-hasura/src/example_queries/stake_pools/allStakePoolFields.graphql
@@ -69,6 +69,9 @@ query allStakePoolFields (
             earnedIn {
                 number
             }
+            receivedIn {
+                number
+            }
         }
         rewards_aggregate {
             aggregate {

--- a/packages/api-cardano-db-hasura/test/rewards.query.test.ts
+++ b/packages/api-cardano-db-hasura/test/rewards.query.test.ts
@@ -25,6 +25,7 @@ describe('rewards', () => {
     expect(rewards.length).toBe(5)
     expect(rewards[0].stakePool.hash).toBeDefined()
     expect(rewards[0].earnedIn.number).toBeDefined()
+    expect(rewards[0].receivedIn.number).toBeDefined()
     expect(rewards[0].type).toBeDefined()
   })
 


### PR DESCRIPTION
# Context
This is a column added to `cardano-db-sync` after the initial implementation here.

# Proposed Solution
A new field to associate the epoch when the reward is included in the
account balance
.
