### PR TITLE
feature: support change to asset ticker length

### DIFF
--- a/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
+++ b/packages/api-cardano-db-hasura/hasura/project/migrations/1589369664961_init/up.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS "Asset" (
     "metadataHash" CHAR(40),
     "name" VARCHAR(50),
     "policyId" BYTEA,
-    "ticker" VARCHAR(5),
+    "ticker" VARCHAR(9),
     "url" VARCHAR(250)
 );
 


### PR DESCRIPTION
# Context
Asset tickers can now be up to 9 characters, but the view is limited to 5 based on the previous spec.

# Proposed Solution
Increase the column definition from 5 to 9 chars

# Important Changes Introduced
N.A.
