### PR TITLE
Fix: Nullable reward epoch received in + cleanup

### DIFF
--- a/packages/api-cardano-db-hasura/schema.graphql
+++ b/packages/api-cardano-db-hasura/schema.graphql
@@ -611,7 +611,7 @@ type Reward {
   address: StakeAddress!
   amount: String!
   earnedIn: Epoch!
-  receivedIn: Epoch!
+  receivedIn: Epoch
   stakePool: StakePool
   type: String!
 }

--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -25,7 +25,6 @@ export class CardanoNodeClient {
   private serverHealthFetcher: DataFetcher<ServerHealth>
 
   constructor (
-    readonly lastConfiguredMajorVersion: number, // Todo: Depreciate
     private logger: Logger = dummyLogger
   ) {
     this.state = null

--- a/packages/api-cardano-db-hasura/src/HasuraClient.ts
+++ b/packages/api-cardano-db-hasura/src/HasuraClient.ts
@@ -43,7 +43,6 @@ export class HasuraClient {
     readonly hasuraCliPath: string,
     readonly hasuraUri: string,
     pollingInterval: number,
-    readonly lastConfiguredMajorVersion: number, // Todo: Depreciate
     private logger: Logger = dummyLogger
   ) {
     this.state = null

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -45,17 +45,14 @@ export * from './config'
       byron: loadGenesis('Byron') as ByronGenesis,
       shelley: loadGenesis('Shelley') as ShelleyGenesis
     }
-    const lastConfiguredMajorVersion = require(config.cardanoNodeConfigPath)['LastKnownBlockVersion-Major']
 
     const cardanoNodeClient = new CardanoNodeClient(
-      lastConfiguredMajorVersion,
       logger
     )
     const hasuraClient = new HasuraClient(
       config.hasuraCliPath,
       config.hasuraUri,
       config.pollingInterval.adaSupply,
-      lastConfiguredMajorVersion,
       logger
     )
     const db = new Db(config.db, logger)


### PR DESCRIPTION
:pushpin: **fix!: Reward.receivedIn nullability**
Rewards are known before being "paid out", so not all rewards
have been received. This change fixes the model to ensure the
upcoming rewards have a nullable relationship to the epoch
received in.

:pushpin: **refactor!: remove remnants of previously deprecated config**
Two class constructor functions have now been updated to reflect
the deprecation of using the last configured major Cardano version,
which were missed in the previous breaking change. There are no
changes to the service config, so it will only impact library users.

