### PR TITLE
fix(api-cardano-db-hasura): define response as optional in metadata server errors

### DIFF
--- a/packages/api-cardano-db-hasura/src/MetadataClient.ts
+++ b/packages/api-cardano-db-hasura/src/MetadataClient.ts
@@ -26,7 +26,7 @@ export class MetadataClient {
     } catch (error) {
       if (error.code === 'ENOTFOUND') {
         throw new errors.HostDoesNotExist('metadata server')
-      } else if (error.response.status !== 404) {
+      } else if (error.response?.status !== 404) {
         throw error
       }
     }


### PR DESCRIPTION
# Context
https://github.com/input-output-hk/cardano-graphql/issues/670#issuecomment-1025991404

# Proposed Solution
Define response as optional on error object

# Important Changes Introduced

