### PR TITLE
Update bug.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Create a bug report
 #title: ""
-labels: ["bug"]
+labels: ["BUG"]
 #assignees:
 #  -
 body:


### PR DESCRIPTION
update default label for form to uppercase "BUG"

# Context

It doesn't seem to be setting default bug label, probably case sensitive

# Proposed Solution


# Important Changes Introduced

