### PR TITLE
fix: trim whitespace from credentials in server config

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -41,11 +41,11 @@ export async function getConfig (): Promise<Config> {
   let db: Config['db']
   try {
     db = {
-      database: env.postgres.db || (await fs.readFile(env.postgres.dbFile, 'utf8')).toString(),
+      database: env.postgres.db || (await fs.readFile(env.postgres.dbFile, 'utf8')).toString().trim(),
       host: env.postgres.host,
-      password: env.postgres.password || (await fs.readFile(env.postgres.passwordFile, 'utf8')).toString(),
+      password: env.postgres.password || (await fs.readFile(env.postgres.passwordFile, 'utf8')).toString().trim(),
       port: env.postgres.port,
-      user: env.postgres.user || (await fs.readFile(env.postgres.userFile, 'utf8')).toString()
+      user: env.postgres.user || (await fs.readFile(env.postgres.userFile, 'utf8')).toString().trim()
     }
   } catch (error) {
     throw new MissingConfig('Database configuration cannot be read')


### PR DESCRIPTION
# Context
This fixes #712 and corrects the open PR #713, which seems to be unattended.

# Proposed Solution
Strips whitespace from server credentials loaded from the docker-compose secrets. 
