### PR TITLE
fix: gracefully shutdown cardano-db-sync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - db-sync-data:/var/lib/cexplorer
       - node-ipc:/node-ipc
     restart: on-failure
+    stop_signal: SIGINT
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
# Context
- cardano-db-sync ignores SIGTERM, which is the default signal sent when stopping Docker containers
- Ogmios' `cardano-node-ogmios` sets this within the Dockerfile
https://github.com/CardanoSolutions/ogmios/blob/c32341e56ccbeb1cf1e803d4607699668a1e2cc2/Dockerfile#L73


