### PR TITLE
chore: bump Ogmios to master HEAD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
         - NETWORK=${NETWORK:-mainnet}
       cache_from: [ cardanosolutions/cardano-node-ogmios:latest ]
       context: ./ogmios
-    image: cardanosolutions/cardano-node-ogmios:${CARDANO_NODE_OGMIOS_VERSION:-v5.5.1}-${NETWORK:-mainnet}
+    image: cardanosolutions/cardano-node-ogmios:${CARDANO_NODE_OGMIOS_VERSION:-v5.5.2_1.35.2}-${NETWORK:-mainnet}
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Pinning an unreleased state for _testnet_ compatibility, to work around the issue being discussed [here](https://github.com/CardanoSolutions/ogmios/pull/241#issuecomment-1198940107). The Docker tagging strategy has also changed for the better.