### PR TITLE
fix: mount local config into cardano-node-ogmios

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     volumes:
       - node-db:/db
       - node-ipc:/ipc
+      - ./config/network/${NETWORK:-mainnet}:/config
 
   cardano-db-sync:
     image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.0.4}


### PR DESCRIPTION
# Context
Fixes #758 
The current version of `cardano-node-ogmios` contains p2p configuration, as it was released prior to the transformation to avoid the p2p bug in the core. 

# Proposed Solution
Mount the local config to override the invalid config in the image. The Docker Compose file is already dependent on having `cardano-configurations` cloned, so this change has no impact on usability.

# Important Changes Introduced

