### PR TITLE
fix: Reconnect Ogmios sockets on unexpected disconnects, and logging fixes

### DIFF
--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -2,7 +2,8 @@ import { AssetSupply, Transaction } from './graphql_types'
 import pRetry from 'p-retry'
 import util, { DataFetcher, errors, ModuleState } from '@cardano-graphql/util'
 import {
-  ConnectionConfig, createConnectionObject, createInteractionContext,
+  ConnectionConfig,
+  createConnectionObject,
   createStateQueryClient,
   createTxSubmissionClient,
   getServerHealth,
@@ -12,6 +13,7 @@ import {
   TxSubmission
 } from '@cardano-ogmios/client'
 import { dummyLogger, Logger } from 'ts-log'
+import { createInteractionContextWithLogger } from './util'
 
 const MODULE_NAME = 'CardanoNodeClient'
 
@@ -61,28 +63,10 @@ export class CardanoNodeClient {
     await pRetry(async () => {
       await this.serverHealthFetcher.initialize()
       this.stateQueryClient = await createStateQueryClient(
-        await createInteractionContext(
-          (error) => {
-            this.logger.error({ module: MODULE_NAME, error: error.name }, error.message)
-          },
-          this.logger.info,
-          {
-            connection: ogmiosConnectionConfig,
-            interactionType: 'LongRunning'
-          }
-        )
+        await createInteractionContextWithLogger(ogmiosConnectionConfig, this.logger, MODULE_NAME)
       )
       this.txSubmissionClient = await createTxSubmissionClient(
-        await createInteractionContext(
-          (error) => {
-            this.logger.error({ module: MODULE_NAME, error: error.name }, error.message)
-          },
-          this.logger.info,
-          {
-            connection: ogmiosConnectionConfig,
-            interactionType: 'LongRunning'
-          }
-        )
+        await createInteractionContextWithLogger(ogmiosConnectionConfig, this.logger, MODULE_NAME)
       )
     }, {
       factor: 1.2,

--- a/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
+++ b/packages/api-cardano-db-hasura/src/CardanoNodeClient.ts
@@ -62,11 +62,15 @@ export class CardanoNodeClient {
     )
     await pRetry(async () => {
       await this.serverHealthFetcher.initialize()
+      const onClose = async () => {
+        await this.shutdown()
+        await this.initialize(ogmiosConnectionConfig)
+      }
       this.stateQueryClient = await createStateQueryClient(
-        await createInteractionContextWithLogger(ogmiosConnectionConfig, this.logger, MODULE_NAME)
+        await createInteractionContextWithLogger(ogmiosConnectionConfig, this.logger, MODULE_NAME, onClose)
       )
       this.txSubmissionClient = await createTxSubmissionClient(
-        await createInteractionContextWithLogger(ogmiosConnectionConfig, this.logger, MODULE_NAME)
+        await createInteractionContextWithLogger(ogmiosConnectionConfig, this.logger, MODULE_NAME, onClose)
       )
     }, {
       factor: 1.2,
@@ -86,6 +90,7 @@ export class CardanoNodeClient {
       this.stateQueryClient.shutdown,
       this.txSubmissionClient.shutdown
     ])
+    this.state = null
   }
 
   public async submitTransaction (transaction: string): Promise<Transaction['hash']> {

--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -38,7 +38,10 @@ export class ChainFollower {
     this.state = 'initializing'
     this.logger.info({ module: MODULE_NAME }, 'Initializing')
     await pRetry(async () => {
-      const context = await createInteractionContextWithLogger(ogmiosConfig, this.logger, MODULE_NAME)
+      const context = await createInteractionContextWithLogger(ogmiosConfig, this.logger, MODULE_NAME, async () => {
+        await this.shutdown()
+        await this.initialize(ogmiosConfig)
+      })
       this.chainSyncClient = await createChainSyncClient(
         context,
         {
@@ -122,7 +125,7 @@ export class ChainFollower {
     this.logger.info({ module: MODULE_NAME }, 'Shutting down')
     await this.chainSyncClient.shutdown()
     await this.queue.stop()
-    this.state = 'initialized'
+    this.state = null
     this.logger.info(
       { module: MODULE_NAME },
       'Shutdown complete')

--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -1,7 +1,6 @@
 import {
   ChainSync,
   createChainSyncClient,
-  createInteractionContext,
   isAlonzoBlock,
   isBabbageBlock,
   isMaryBlock,
@@ -13,6 +12,7 @@ import util, { assetFingerprint, errors, RunnableModuleState } from '@cardano-gr
 import { HasuraClient } from './HasuraClient'
 import PgBoss from 'pg-boss'
 import { dummyLogger, Logger } from 'ts-log'
+import { createInteractionContextWithLogger } from './util'
 
 const MODULE_NAME = 'ChainFollower'
 
@@ -38,16 +38,7 @@ export class ChainFollower {
     this.state = 'initializing'
     this.logger.info({ module: MODULE_NAME }, 'Initializing')
     await pRetry(async () => {
-      const context = await createInteractionContext(
-        this.logger.error,
-        (code, reason) => {
-          this.logger.error({ module: MODULE_NAME, code }, reason)
-        },
-        {
-          connection: ogmiosConfig,
-          interactionType: 'LongRunning'
-        }
-      )
+      const context = await createInteractionContextWithLogger(ogmiosConfig, this.logger, MODULE_NAME)
       this.chainSyncClient = await createChainSyncClient(
         context,
         {

--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -25,19 +25,19 @@ export class ChainFollower {
   constructor (
     readonly hasuraClient: HasuraClient,
     private logger: Logger = dummyLogger,
-    queueConfig: Config['db']
+    private queueConfig: Config['db']
   ) {
     this.state = null
-    this.queue = new PgBoss({
-      application_name: 'cardano-graphql',
-      ...queueConfig
-    })
   }
 
   public async initialize (ogmiosConfig: Config['ogmios'], getMostRecentPoint: () => Promise<PointOrOrigin[]>) {
     if (this.state !== null) return
     this.state = 'initializing'
     this.logger.info({ module: MODULE_NAME }, 'Initializing')
+    this.queue = new PgBoss({
+      application_name: 'cardano-graphql',
+      ...this.queueConfig
+    })
     await pRetry(async () => {
       const context = await createInteractionContextWithLogger(ogmiosConfig, this.logger, MODULE_NAME, async () => {
         await this.shutdown()

--- a/packages/api-cardano-db-hasura/src/ChainFollower.ts
+++ b/packages/api-cardano-db-hasura/src/ChainFollower.ts
@@ -13,6 +13,7 @@ import { HasuraClient } from './HasuraClient'
 import PgBoss from 'pg-boss'
 import { dummyLogger, Logger } from 'ts-log'
 import { createInteractionContextWithLogger } from './util'
+import { PointOrOrigin } from '@cardano-ogmios/schema'
 
 const MODULE_NAME = 'ChainFollower'
 
@@ -33,14 +34,15 @@ export class ChainFollower {
     })
   }
 
-  public async initialize (ogmiosConfig: Config['ogmios']) {
+  public async initialize (ogmiosConfig: Config['ogmios'], getMostRecentPoint: () => Promise<PointOrOrigin[]>) {
     if (this.state !== null) return
     this.state = 'initializing'
     this.logger.info({ module: MODULE_NAME }, 'Initializing')
     await pRetry(async () => {
       const context = await createInteractionContextWithLogger(ogmiosConfig, this.logger, MODULE_NAME, async () => {
         await this.shutdown()
-        await this.initialize(ogmiosConfig)
+        await this.initialize(ogmiosConfig, getMostRecentPoint)
+        await this.start(await getMostRecentPoint())
       })
       this.chainSyncClient = await createChainSyncClient(
         context,
@@ -115,6 +117,7 @@ export class ChainFollower {
     this.logger.info({ module: MODULE_NAME }, 'Starting')
     await this.queue.start()
     await this.chainSyncClient.startSync(points)
+    this.state = 'running'
     this.logger.info({ module: MODULE_NAME }, 'Started')
   }
 
@@ -123,8 +126,10 @@ export class ChainFollower {
       throw new errors.ModuleIsNotInitialized(MODULE_NAME, 'shutdown')
     }
     this.logger.info({ module: MODULE_NAME }, 'Shutting down')
-    await this.chainSyncClient.shutdown()
     await this.queue.stop()
+    if (this.chainSyncClient.context.socket.readyState === this.chainSyncClient.context.socket.OPEN) {
+      await this.chainSyncClient.shutdown()
+    }
     this.state = null
     this.logger.info(
       { module: MODULE_NAME },

--- a/packages/api-cardano-db-hasura/src/util.ts
+++ b/packages/api-cardano-db-hasura/src/util.ts
@@ -1,0 +1,20 @@
+import { ConnectionConfig, createInteractionContext } from '@cardano-ogmios/client'
+import { Logger } from 'ts-log'
+
+export const createInteractionContextWithLogger = (connection: ConnectionConfig, logger: Logger, module: string) =>
+  createInteractionContext(
+    (error) => {
+      logger.error({ module, error }, error.message)
+    },
+    (code, reason) => {
+      if (code === 1006) {
+        logger.error({ module, code }, 'Connection was closed abnormally')
+      } else {
+        logger.info({ module, code }, reason)
+      }
+    },
+    {
+      connection,
+      interactionType: 'LongRunning'
+    }
+  )

--- a/packages/api-cardano-db-hasura/src/util.ts
+++ b/packages/api-cardano-db-hasura/src/util.ts
@@ -1,16 +1,17 @@
 import { ConnectionConfig, createInteractionContext } from '@cardano-ogmios/client'
 import { Logger } from 'ts-log'
 
-export const createInteractionContextWithLogger = (connection: ConnectionConfig, logger: Logger, module: string) =>
+export const createInteractionContextWithLogger = (connection: ConnectionConfig, logger: Logger, module: string, onClose?: () => Promise<void>) =>
   createInteractionContext(
     (error) => {
       logger.error({ module, error }, error.message)
     },
-    (code, reason) => {
-      if (code === 1006) {
-        logger.error({ module, code }, 'Connection was closed abnormally')
-      } else {
+    async (code, reason) => {
+      if (code === 1000) {
         logger.info({ module, code }, reason)
+      } else {
+        logger.error({ module, code }, 'Connection closed')
+        await onClose?.()
       }
     },
     {


### PR DESCRIPTION
# Context
Ogmios disconnects the WebSocket when attempting to submit some invalid payloads. Once disconnected, the server must be restarted. There are also a couple of bugs with the connection context error and close handlers, causing a bunyan error.

# Proposed Solution
- Hoist the context init to DRY the code.
- Fix the handlers to always log a structured object
- Treat `1006` close events as an error, the rest as informational.
- Shutdown and re-initialize the client on unexpected close events.

# Important Changes Introduced


Example of the bunyan error:
```console
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":30,"module":"Server","msg":"Initializing","time":"2022-09-08T09:13:13.201Z","v":0}
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":30,"module":"HasuraClient","msg":"Initializing","time":"2022-09-08T09:13:13.729Z","v":0}
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":30,"module":"CardanoNodeClient","msg":"Initializing. This can take a few minutes...","time":"2022-09-08T09:13:14.315Z","v":0}
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":30,"module":"CardanoNodeClient","msg":"Initialized","time":"2022-09-08T09:13:18.058Z","v":0}
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":30,"module":"MetadataFetchClient","msg":"Initializing","time":"2022-09-08T09:13:18.059Z","v":0}
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":30,"module":"MetadataFetchClient","msg":"Initialized","time":"2022-09-08T09:13:18.189Z","v":0}
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":30,"module":"ChainFollower","msg":"Initializing","time":"2022-09-08T09:13:18.189Z","v":0}
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":30,"module":"ChainFollower","msg":"Initialized","time":"2022-09-08T09:13:18.202Z","v":0}
bunyan usage error: /app/node_modules/ws/lib/websocket.js:246: attempt to log with an unbound log method: `this` is: <ref *1> WebSocket {
  _events: [Object: null prototype] {},
  _eventsCount: 0,
  _maxListeners: undefined,
  _binaryType: 'nodebuffer',
  _closeCode: 1006,
  _closeFrameReceived: false,
  _closeFrameSent: false,
  _closeMessage: '',
  _closeTimer: null,
  _extensions: {},
  _protocol: '',
  _readyState: 3,
  _receiver: Receiver {
    _writableState: WritableState {
      objectMode: false,
      highWaterMark: 16384,
      finalCalled: false,
      needDrain: false,
      ending: true,
      ended: true,
      finished: true,
      destroyed: true,
      decodeStrings: true,
      defaultEncoding: 'utf8',
      length: 0,
      writing: false,
      corked: 0,
      sync: true,
      bufferProcessing: false,
      onwrite: [Function: bound onwrite],
      writecb: null,
      writelen: 0,
      afterWriteTickInfo: null,
      buffered: [],
      bufferedIndex: 0,
      allBuffers: true,
      allNoop: true,
      pendingcb: 0,
      prefinished: true,
      errorEmitted: false,
      emitClose: true,
      autoDestroy: true,
      errored: null,
      closed: true
    },
    _events: [Object: null prototype] {},
    _eventsCount: 0,
    _maxListeners: undefined,
    _binaryType: 'nodebuffer',
    _extensions: {},
    _isServer: false,
    _maxPayload: 134217728,
    _bufferedBytes: 0,
    _buffers: [],
    _compressed: false,
    _payloadLength: 0,
    _mask: undefined,
    _fragmented: 0,
    _masked: false,
    _fin: false,
    _opcode: 0,
    _totalPayloadLength: 0,
    _messageLength: 0,
    _fragments: [],
    _state: 0,
    _loop: false,
    [Symbol(kCapture)]: false,
    [Symbol(websocket)]: [Circular *1]
  },
  _sender: Sender {
    _extensions: {},
    _socket: Socket {
      connecting: false,
      _hadError: false,
      _parent: null,
      _host: 'cardano-node-ogmios',
      _readableState: [ReadableState],
      _events: [Object: null prototype],
      _eventsCount: 2,
      _maxListeners: undefined,
      _writableState: [WritableState],
      allowHalfOpen: false,
      _sockname: null,
      _pendingData: null,
      _pendingEncoding: '',
      server: null,
      _server: null,
      parser: null,
      _httpMessage: null,
      timeout: 0,
      write: [Function: writeAfterFIN],
      [Symbol(async_id_symbol)]: 299,
      [Symbol(kHandle)]: null,
      [Symbol(kSetNoDelay)]: true,
      [Symbol(lastWriteQueueSize)]: 0,
      [Symbol(timeout)]: null,
      [Symbol(kBuffer)]: null,
      [Symbol(kBufferCb)]: null,
      [Symbol(kBufferGen)]: null,
      [Symbol(kCapture)]: false,
      [Symbol(kBytesRead)]: 138,
      [Symbol(kBytesWritten)]: 233,
      [Symbol(RequestTimeout)]: undefined,
      [Symbol(websocket)]: undefined
    },
    _firstFragment: true,
    _compress: false,
    _bufferedBytes: 0,
    _deflating: false,
    _queue: []
  },
  _socket: Socket {
    connecting: false,
    _hadError: false,
    _parent: null,
    _host: 'cardano-node-ogmios',
    _readableState: ReadableState {
      objectMode: false,
      highWaterMark: 16384,
      buffer: BufferList { head: null, tail: null, length: 0 },
      length: 0,
      pipes: [],
      flowing: true,
      ended: true,
      endEmitted: true,
      reading: false,
      sync: false,
      needReadable: false,
      emittedReadable: false,
      readableListening: false,
      resumeScheduled: false,
      errorEmitted: false,
      emitClose: false,
      autoDestroy: false,
      destroyed: true,
      errored: null,
      closed: true,
      closeEmitted: true,
      defaultEncoding: 'utf8',
      awaitDrainWriters: null,
      multiAwaitDrain: false,
      readingMore: false,
      dataEmitted: true,
      decoder: null,
      encoding: null,
      [Symbol(kPaused)]: false
    },
    _events: [Object: null prototype] {
      end: [Function: onReadableStreamEnd],
      error: [Function: socketOnError]
    },
    _eventsCount: 2,
    _maxListeners: undefined,
    _writableState: WritableState {
      objectMode: false,
      highWaterMark: 16384,
      finalCalled: true,
      needDrain: false,
      ending: true,
      ended: true,
      finished: true,
      destroyed: true,
      decodeStrings: false,
      defaultEncoding: 'utf8',
      length: 0,
      writing: false,
      corked: 0,
      sync: false,
      bufferProcessing: false,
      onwrite: [Function: bound onwrite],
      writecb: null,
      writelen: 0,
      afterWriteTickInfo: null,
      buffered: [],
      bufferedIndex: 0,
      allBuffers: true,
      allNoop: true,
      pendingcb: 0,
      prefinished: true,
      errorEmitted: false,
      emitClose: false,
      autoDestroy: false,
      errored: null,
      closed: true,
      closeEmitted: false,
      writable: true
    },
    allowHalfOpen: false,
    _sockname: null,
    _pendingData: null,
    _pendingEncoding: '',
    server: null,
    _server: null,
    parser: null,
    _httpMessage: null,
    timeout: 0,
    write: [Function: writeAfterFIN],
    [Symbol(async_id_symbol)]: 299,
    [Symbol(kHandle)]: null,
    [Symbol(kSetNoDelay)]: true,
    [Symbol(lastWriteQueueSize)]: 0,
    [Symbol(timeout)]: null,
    [Symbol(kBuffer)]: null,
    [Symbol(kBufferCb)]: null,
    [Symbol(kBufferGen)]: null,
    [Symbol(kCapture)]: false,
    [Symbol(kBytesRead)]: 138,
    [Symbol(kBytesWritten)]: 233,
    [Symbol(RequestTimeout)]: undefined,
    [Symbol(websocket)]: undefined
  },
  _bufferedAmount: 0,
  _isServer: false,
  _redirects: 0,
  _url: 'ws://cardano-node-ogmios:1337/',
  _req: null,
  [Symbol(kCapture)]: false
}
{"name":"cardano-graphql","hostname":"5fd0492a7031","pid":1,"level":50,"module":"ChainFollower","code":1006,"msg":"","time":"2022-09-08T09:13:21.235Z","v":0}
```