### PR TITLE
build: fix set-interval-async dependency

### DIFF
--- a/packages/api-cardano-db-hasura/package.json
+++ b/packages/api-cardano-db-hasura/package.json
@@ -72,7 +72,6 @@
     "@types/node": "^14.0.13",
     "@types/object-hash": "^1.3.4",
     "@types/pg": "^7.14.4",
-    "@types/set-interval-async": "^1.0.0",
     "@types/temp-write": "^4.0.0",
     "shx": "^0.3.2",
     "typescript": "^3.9.5"

--- a/packages/server/src/Server.ts
+++ b/packages/server/src/Server.ts
@@ -17,8 +17,7 @@ import {
 } from './errors'
 import { allowListMiddleware } from './express_middleware'
 import { dummyLogger, Logger } from 'ts-log'
-import { setIntervalAsync, SetIntervalAsyncTimer } from 'set-interval-async/dynamic'
-import { clearIntervalAsync } from 'set-interval-async'
+import { clearIntervalAsync, setIntervalAsync, SetIntervalAsyncTimer } from 'set-interval-async/dynamic'
 import { RunnableModuleState } from '@cardano-graphql/util'
 
 export type Config = {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -27,6 +27,7 @@
     "graphql-bigint": "^1.0.0",
     "graphql-tag": "^2.10.3",
     "p-retry": "^4.2.0",
+    "set-interval-async": "^2.0.3",
     "ts-log": "^2.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
# Context
- The `util` package depends on `set-interval-async`, but it's not explicitly defined.
- `Server.ts` has a duplicate line import statement for the same package.
- `api-cardano-db-hasura` has an unnecessary devDep 

# Proposed Solution
- Add the explicit dependency
- Consolidate to as single imports
- Remove the devDep