### PR TITLE
Update node version for testnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ docker-compose logs -f
   <summary><i>preprod</i></summary>
 
 ``` console
+CARDANO_NODE_VERSION=1.35.4 \
 DOCKER_BUILDKIT=1 \
 COMPOSE_DOCKER_CLI_BUILD=1 \
 NETWORK=preprod \
@@ -89,6 +90,7 @@ docker-compose -p preprod logs -f
   <summary><i>preview</i></summary>
 
 ``` console
+CARDANO_NODE_VERSION=1.35.4 \
 DOCKER_BUILDKIT=1 \
 COMPOSE_DOCKER_CLI_BUILD=1 \
 NETWORK=preview \


### PR DESCRIPTION
# Context

The default cardano node version `1.35.3` is no longer able to connect with `preprod-node.world.dev.cardano.org`.

# Proposed Solution

Update README section for testnet commands by specifying the `1.35.4` version of cardano-node. This fixes #778 

# Important Changes Introduced

None.